### PR TITLE
Enhance prompt and asset library handling with examples directory sup…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ examples workflow runs confined to the examples directory rather than to the
 writable one. Packaged `dw/workflows/` is off the path - it is what `builtin:`
 sub-workflow steps name, resolved in `dw/workflow.py`.
 
+The prompt and asset libraries have the same shape: each `--examples-dir`
+brings the `prompts/` and `assets/` beside it (`example_libraries` in
+`dw/workspace.py`), pinned into `DW_PROMPT_PATH` / `DW_ASSET_PATH` by
+`dw.serve` so the spawned worker resolves as the API does. `prompt_search_path`
+/ `asset_search_path` put the workspace's own library first, so a workspace
+name shadows an example's; `GET /api/prompts` and `GET /api/assets` span the
+path and tag each entry with its `origin`; writes (`PUT /api/prompts`, uploads,
+keep-as-asset) only ever land in the workspace, and deleting a read-only prompt
+answers 403.
+
 ### Workspaces
 
 `dw/workspace.py` resolves the one directory a run's content belongs to -

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -37,7 +37,9 @@ load entirely.
   listed and where a save lands.
 - **Prompts** — the prompt library under `--prompt-dir` (default: discovered
   the way a CLI run discovers it, then pinned for every job, so the page and
-  `prompt:` resolution always agree): stored prompts as
+  `prompt:` resolution always agree), plus the read-only `prompts/` beside
+  each `--examples-dir`, so an example's `prompt:` references resolve: stored
+  prompts as
   cards with descriptions, intended-model badges, and tags, foldered the
   same way workflows are. Each opens in an editor with form, split, and
   schema-aware JSON views, and an **Enhance with AI** panel that expands an

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -134,6 +134,32 @@ python -m dw.serve --workspace ~/studio --examples-dir ~/src/diffusers-workflow/
 its `origin` and `writable`, which is how the UI knows to hide delete and how
 an MCP client can tell what it may change.
 
+### The prompts and assets an examples tree brings with it
+
+An example workflow references the prompts and media that live beside its
+tree, not the ones in your workspace, so each `--examples-dir` puts those on
+the back of the two libraries as well: the `prompts/` and `assets/` folders
+beside the directory (or inside it, if that is where they are). Both libraries
+work exactly like the workflow path — your workspace's own is searched first
+and a name there shadows the example's, reads span everything, and writes only
+ever reach your own:
+
+```
+<workspace>/prompts/      yours, writable — every save lands here
+<--examples-dir>/../prompts   read-only
+
+<workspace>/assets/       yours, writable — uploads and "keep as asset" land here
+<--examples-dir>/../assets    read-only
+```
+
+So the command above makes `workflows/models/flux-dev.json`'s
+`"prompt:flux/biomechanical_daffodil"` resolve out of the checkout, without
+copying the prompt library into the workspace. `GET /api/prompts` and
+`GET /api/assets` report the roots as `prompt_dirs` / `asset_dirs` and tag
+each entry with its `origin`; deleting a prompt that came from a read-only
+library is refused with a 403, and saving one writes a copy into your
+workspace the way saving an example workflow does.
+
 The packaged workflows in `dw/workflows/` are deliberately *not* on the path.
 They are the pieces a `builtin:` sub-workflow step names, resolved by the
 engine where that step is read — not workflows to browse or run on their own.

--- a/dw/assets.py
+++ b/dw/assets.py
@@ -17,7 +17,7 @@ import logging
 import os
 
 from .security import validate_asset_reference, validate_path
-from .workspace import ASSETS_SUBDIR, discover_library
+from .workspace import ASSETS_SUBDIR, discover_library, library_fallbacks
 
 logger = logging.getLogger("dw")
 
@@ -72,6 +72,23 @@ def is_asset_reference(value):
     return isinstance(value, str) and value.startswith(ASSET_PREFIX)
 
 
+def asset_search_path(asset_dir=None, base_dir=None):
+    """Every directory an 'asset:' reference is looked for in, in order.
+
+    The workspace's own library first, then the read-only ones an entry
+    point put on the path (workspace.library_fallbacks - the assets a
+    --examples-dir tree brings with it), so an example workflow reaches the
+    media it ships with while an upload still lands in the workspace.
+
+    Args:
+        asset_dir: The first directory; defaults to get_asset_dir()
+        base_dir: The workflow file's directory, anchoring discovery when no
+            asset directory is configured
+    """
+    primary = asset_dir or get_asset_dir(base_dir)
+    return [primary] + library_fallbacks(ASSETS_SUBDIR, primary)
+
+
 def resolve_asset_reference(reference, asset_dir=None, base_dir=None):
     """Resolve an 'asset:' reference to the file it names.
 
@@ -87,23 +104,25 @@ def resolve_asset_reference(reference, asset_dir=None, base_dir=None):
     Raises:
         InvalidInputError: If the name is not a valid asset name
         PathTraversalError: If the name escapes the asset directory
-        ValueError: If no file exists under that name
+        ValueError: If no file exists under that name in any directory on
+            the search path
     """
     name = validate_asset_reference(reference.removeprefix(ASSET_PREFIX).strip())
-    asset_dir = asset_dir or get_asset_dir(base_dir)
-    # Confined to the library: the name is joined onto a directory, so the
-    # containment check is what makes a name a name rather than a path
-    # allow_create leaves "does not exist" to the check below, which can say
-    # what an asset reference is instead of what a path is
-    path = validate_path(os.path.join(asset_dir, name), asset_dir)
-    if not os.path.isfile(path):
-        raise ValueError(
-            f"Asset '{name}' not found in {asset_dir} - an 'asset:' reference "
-            f"names a file in the asset library, with its extension, like "
-            f"'asset:iris.jpg' or 'asset:gyre/frame_1.jpg'"
-        )
-    logger.debug(f"Resolved {reference} to {path}")
-    return path
+    roots = asset_search_path(asset_dir, base_dir)
+    for root in roots:
+        # Confined to the library it was found in: the name is joined onto a
+        # directory, so the containment check is what makes a name a name
+        # rather than a path
+        path = validate_path(os.path.join(root, name), root)
+        if os.path.isfile(path):
+            logger.debug(f"Resolved {reference} to {path}")
+            return path
+    searched = ", ".join(roots)
+    raise ValueError(
+        f"Asset '{name}' not found in {searched} - an 'asset:' reference "
+        f"names a file in the asset library, with its extension, like "
+        f"'asset:iris.jpg' or 'asset:gyre/frame_1.jpg'"
+    )
 
 
 def fetch_asset(reference, asset_dir=None, base_dir=None):

--- a/dw/prompts.py
+++ b/dw/prompts.py
@@ -13,7 +13,7 @@ import os
 
 from .schema import load_schema, validate_data
 from .security import validate_prompt_path, validate_prompt_reference
-from .workspace import PROMPTS_SUBDIR, discover_library
+from .workspace import PROMPTS_SUBDIR, discover_library, library_fallbacks
 
 logger = logging.getLogger("dw")
 
@@ -53,6 +53,24 @@ def get_prompt_dir(base_dir=None):
     return discover_library(PROMPTS_SUBDIR, "DW_PROMPT_DIR", base_dir)
 
 
+def prompt_search_path(prompt_dir=None, base_dir=None):
+    """Every directory a 'prompt:' reference is looked for in, in order.
+
+    The library a save would write to comes first, then the read-only ones
+    an entry point put on the path (workspace.library_fallbacks - the
+    prompts a --examples-dir tree brings with it). A name found earlier
+    shadows the same name later, the way it does on the workflow search
+    path.
+
+    Args:
+        prompt_dir: The first directory; defaults to get_prompt_dir()
+        base_dir: The workflow file's directory, anchoring discovery when no
+            prompt directory is configured
+    """
+    primary = prompt_dir or get_prompt_dir(base_dir)
+    return [primary] + library_fallbacks(PROMPTS_SUBDIR, primary)
+
+
 def resolve_prompt_reference(reference, prompt_dir=None, base_dir=None):
     """Resolve a 'prompt:' reference to the file it names.
 
@@ -67,17 +85,20 @@ def resolve_prompt_reference(reference, prompt_dir=None, base_dir=None):
 
     Raises:
         InvalidInputError: If the name is not a valid prompt name
-        ValueError: If no prompt file exists under that name
+        ValueError: If no prompt file exists under that name in any directory
+            on the search path
     """
     name = validate_prompt_reference(reference.removeprefix(PROMPT_PREFIX).strip())
-    prompt_dir = prompt_dir or get_prompt_dir(base_dir)
-    path = os.path.join(prompt_dir, name + ".json")
-    if not os.path.isfile(path):
-        raise ValueError(
-            f"No prompt named '{name}' in {prompt_dir} - a prompt reference names "
-            f"a .json file under the prompt directory, without the extension"
-        )
-    return validate_prompt_path(path, prompt_dir)
+    roots = prompt_search_path(prompt_dir, base_dir)
+    for root in roots:
+        path = os.path.join(root, name + ".json")
+        if os.path.isfile(path):
+            return validate_prompt_path(path, root)
+    searched = ", ".join(roots)
+    raise ValueError(
+        f"No prompt named '{name}' in {searched} - a prompt reference names "
+        f"a .json file under the prompt directory, without the extension"
+    )
 
 
 def load_prompt(path):

--- a/dw/serve.py
+++ b/dw/serve.py
@@ -61,7 +61,10 @@ def main():
         metavar="DIR",
         help="A read-only directory of workflows to offer alongside the "
         "workspace's own - a checkout's workflows/ tree, say. Repeatable. "
-        "Saves never go here: they always land in --workflow-dir",
+        "Saves never go here: they always land in --workflow-dir. The "
+        "prompts/ and assets/ beside such a tree come with it, read-only, "
+        "at the back of the prompt and asset libraries, so an example runs "
+        "with the prompts and media it references",
     )
     parser.add_argument(
         "--asset-dir",
@@ -119,7 +122,7 @@ def main():
     # Resolved and pinned before anything derives a directory from it - the
     # spawned worker inherits the environment variable, the way it inherits
     # the prompt directory and the trust flag below
-    from .workspace import resolve_workspace, set_workspace
+    from .workspace import PROMPTS_SUBDIR, resolve_workspace, set_workspace
 
     workspace = set_workspace(resolve_workspace(args.workspace))
     workflow_dir = args.workflow_dir or workspace.workflows
@@ -182,6 +185,18 @@ def main():
         args.prompt_dir or get_prompt_dir(base_dir=os.path.abspath(workflow_dir))
     )
     os.environ["DW_PROMPT_DIR"] = prompt_dir
+
+    # An --examples-dir tree brings the prompts and assets its workflows
+    # reference along with it, and those live beside the tree rather than in
+    # this workspace. Putting them on the read-only end of each library's
+    # search path is what lets an example run as it shipped: the workspace's
+    # own library is still searched first and is still the only one written
+    # to. Pinned in the environment, so the worker resolves as the API does
+    from .workspace import ASSETS_SUBDIR, example_libraries, set_library_fallbacks
+
+    example_dirs = example_libraries(args.examples_dirs)
+    set_library_fallbacks(PROMPTS_SUBDIR, example_dirs[PROMPTS_SUBDIR])
+    set_library_fallbacks(ASSETS_SUBDIR, example_dirs[ASSETS_SUBDIR])
 
     try:
         import uvicorn

--- a/dw/server/app.py
+++ b/dw/server/app.py
@@ -57,18 +57,23 @@ from ..result import read_embedded_metadata
 from ..hub_cache import scan_models, delete_model, DownloadManager
 from ..runs import strip_run_id
 from ..workspace import (
+    ASSETS_SUBDIR,
     DEFAULT_WORKSPACE_NAME,
+    PROMPTS_SUBDIR,
     ConfiguredWorkspace,
     NotAWorkspaceError,
     Workspace,
     _holds_a_workspace,
     create_workspace,
     delete_workspace,
+    example_libraries,
     named_workspace,
     workspace_contents,
     workspace_names,
 )
 from ..workflow_sources import (
+    EXAMPLES_ORIGIN,
+    WORKSPACE_ORIGIN,
     find_workflow,
     listing,
     resolve_in_source,
@@ -310,13 +315,16 @@ def resolve_workflow_reference(workflow_path, sources):
 _prompt_detail_cache = {}
 
 
-def prompt_details(prompt_dir, names):
+def prompt_details(paths):
     """Per-prompt card metadata: description, intended model, tags - and
     the text itself, which the editors show as the tooltip wherever a
-    prompt: reference stands in for it."""
+    prompt: reference stands in for it.
+
+    Keyed by path rather than by name under one directory: the prompt
+    library is a search path now, and two roots can hold the same name.
+    """
     details = {}
-    for name in names:
-        path = os.path.join(prompt_dir, f"{name}.json")
+    for name, path in paths.items():
         try:
             mtime = os.path.getmtime(path)
         except OSError:
@@ -338,7 +346,10 @@ def prompt_details(prompt_dir, names):
             detail = {"description": "", "intended_model": "", "tags": [], "text": ""}
         _prompt_detail_cache[path] = (mtime, detail)
         details[name] = detail
-    _prune_detail_cache(_prompt_detail_cache, prompt_dir, names)
+    # By existence, not by what this listing named: the cache spans every
+    # root on the search path, and one listing shows only the names that
+    # were not shadowed
+    _prune_missing(_prompt_detail_cache)
     return details
 
 
@@ -526,6 +537,14 @@ def create_app(
     # saves only ever reach the front
     app.state.workflow_sources = workflow_sources(workflow_dir, examples_dirs)
     app.state.prompt_dir = prompt_dir
+    # The read-only libraries the --examples-dir trees bring with them: an
+    # example workflow references the prompts and assets that live beside
+    # its tree, not the ones in this workspace. They are searched after the
+    # workspace's own and never written to - a save of an example prompt
+    # lands in the workspace, the way saving an example workflow does
+    _example_libraries = example_libraries(examples_dirs)
+    app.state.example_prompt_dirs = _example_libraries[PROMPTS_SUBDIR]
+    app.state.example_asset_dirs = _example_libraries[ASSETS_SUBDIR]
     # Where uploads land and 'asset:' references resolve. None when the
     # caller configured no asset library: uploads then fall back to the
     # output directory's uploads/ subfolder, as they did before there was one
@@ -1203,15 +1222,57 @@ def create_app(
         except InvalidInputError:
             return False
 
+    def _prompt_roots():
+        """The prompt search path: the library this server writes to, then
+        the read-only ones an --examples-dir tree brought with it. A name in
+        an earlier root shadows the same name later, as on the workflow
+        search path."""
+        roots = [app.state.prompt_dir]
+        primary = os.path.abspath(app.state.prompt_dir)
+        for root in app.state.example_prompt_dirs:
+            if os.path.abspath(root) != primary:
+                roots.append(root)
+        return roots
+
+    def _find_prompt(name):
+        """(path, writable) for the first root on the search path that holds
+        this name. 404s when no root does, the way resolve_prompt_name does
+        for a name that cannot be referenced at all."""
+        for index, root in enumerate(_prompt_roots()):
+            try:
+                # allow_create so a name that is simply absent from this root
+                # is a miss to carry on from, rather than a 404 raised out of
+                # the middle of the search
+                path = resolve_prompt_name(root, name, allow_create=True)
+            except HTTPException as error:
+                # a name no workflow could reference is a miss too, not the
+                # 400 a save would get for it
+                raise HTTPException(status_code=404, detail=error.detail)
+            if os.path.isfile(path):
+                return path, index == 0
+        raise HTTPException(status_code=404, detail=f"Unknown prompt: {name}")
+
     @app.get("/api/prompts")
     def list_prompts():
         # A stray file too deep or oddly named can sit in the directory, but
         # no workflow could reference it - listing it would only invite that
-        names = [n for n in workflow_names(app.state.prompt_dir) if referenceable(n)]
+        paths = {}
+        origins = {}
+        roots = _prompt_roots()
+        for index, root in enumerate(roots):
+            for name in workflow_names(root):
+                if referenceable(name) and name not in paths:
+                    paths[name] = os.path.join(root, f"{name}.json")
+                    origins[name] = WORKSPACE_ORIGIN if index == 0 else EXAMPLES_ORIGIN
+        names = sorted(paths)
         return {
+            # The writable library, unchanged: what a save is written to,
+            # and what a client that predates the search path expects
             "prompt_dir": app.state.prompt_dir,
+            "prompt_dirs": roots,
             "prompts": names,
-            "details": prompt_details(app.state.prompt_dir, names),
+            "origins": origins,
+            "details": prompt_details(paths),
         }
 
     @app.put("/api/prompts/{name:path}")
@@ -1237,8 +1298,16 @@ def create_app(
 
     @app.delete("/api/prompts/{name:path}")
     def delete_prompt(name: str):
-        """Remove a prompt file from the prompt directory."""
-        path = resolve_prompt_name(app.state.prompt_dir, name)
+        """Remove a prompt file from the prompt directory. A prompt that
+        came from a read-only examples library is not this server's to
+        delete - the same 403 a read-only workflow answers with."""
+        path, writable = _find_prompt(name)
+        if not writable:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Prompt {name} is read-only: it comes from an examples "
+                f"library, not this workspace's prompt directory",
+            )
         os.remove(path)
         logger.info(f"Deleted prompt {name} ({path})")
         return {"name": name, "deleted": True}
@@ -1247,17 +1316,28 @@ def create_app(
     @query_token_ok
     def download_prompt(name: str):
         """Serve a stored prompt as a forced download."""
-        path = resolve_prompt_name(app.state.prompt_dir, name)
+        path, _ = _find_prompt(name)
         return FileResponse(
             path, filename=os.path.basename(path), media_type="application/json"
         )
 
     @app.get("/api/prompts/{name:path}")
     def get_prompt(name: str):
-        path = resolve_prompt_name(app.state.prompt_dir, name)
+        path, writable = _find_prompt(name)
         try:
             with open(path, "r") as file:
-                return JSONResponse(json.load(file))
+                # Which library it came from, the way a workflow carries its
+                # source - the editor offers delete only for a prompt this
+                # server owns, and save-a-copy for a read-only one
+                return JSONResponse(
+                    json.load(file),
+                    headers={
+                        "X-Prompt-Origin": (
+                            WORKSPACE_ORIGIN if writable else EXAMPLES_ORIGIN
+                        ),
+                        "X-Prompt-Writable": "true" if writable else "false",
+                    },
+                )
         except (OSError, json.JSONDecodeError) as e:
             raise HTTPException(status_code=500, detail=f"Could not read prompt: {e}")
 
@@ -1349,6 +1429,20 @@ def create_app(
             files = StaticFiles(directory=root)
             cache[root] = files
         return files
+
+    def _asset_roots(ws):
+        """The asset search path of one workspace: its own library, then the
+        read-only ones an --examples-dir tree brought with it. The same order
+        'asset:' resolves in (dw/assets.asset_search_path), so what the
+        browser lists is what a job would load."""
+        roots = []
+        for root in [ws.assets, *app.state.example_asset_dirs]:
+            if not root:
+                continue
+            root = os.path.abspath(root)
+            if root not in roots and os.path.isdir(root):
+                roots.append(root)
+        return roots
 
     def _served_url(path, ws, version=None):
         """The URL a served file is reachable at: the default workspace's
@@ -1662,35 +1756,46 @@ def create_app(
         asset to be.
         """
         library = ws.assets
-        if not library or not os.path.isdir(library):
-            return {"asset_dir": library, "assets": [], "folders": []}
+        roots = _asset_roots(ws)
+        if not roots:
+            return {"asset_dir": library, "asset_dirs": [], "assets": [], "folders": []}
 
         assets = []
-        try:
-            files = list(_iter_gallery_files(library, group_runs=False))
-        except OSError:
-            files = []
-        for relative, folder, kind, path in files:
+        seen = set()
+        for index, root in enumerate(roots):
             try:
-                stat = os.stat(path)
+                files = list(_iter_gallery_files(root, group_runs=False))
             except OSError:
-                continue
-            assets.append(
-                {
-                    "name": relative,
-                    "reference": f"asset:{relative}",
-                    "folder": folder,
-                    "kind": kind,
-                    "size": stat.st_size,
-                    "mtime": stat.st_mtime,
-                    # For the editor's own preview - fetchable the same
-                    # way an upload's URL is
-                    "url": _served_url(f"/inputs/{quote(relative)}", ws),
-                }
-            )
+                files = []
+            for relative, folder, kind, path in files:
+                # A name in the workspace shadows the same name in an
+                # examples library, exactly as 'asset:' resolution does
+                if relative in seen:
+                    continue
+                try:
+                    stat = os.stat(path)
+                except OSError:
+                    continue
+                seen.add(relative)
+                assets.append(
+                    {
+                        "name": relative,
+                        "reference": f"asset:{relative}",
+                        "folder": folder,
+                        "kind": kind,
+                        "size": stat.st_size,
+                        "mtime": stat.st_mtime,
+                        "origin": WORKSPACE_ORIGIN if index == 0 else EXAMPLES_ORIGIN,
+                        # For the editor's own preview - fetchable the same
+                        # way an upload's URL is
+                        "url": _served_url(f"/inputs/{quote(relative)}", ws),
+                    }
+                )
         assets.sort(key=lambda entry: entry["mtime"], reverse=True)
         return {
+            # The workspace's own library, unchanged: where an upload lands
             "asset_dir": library,
+            "asset_dirs": roots,
             "assets": assets,
             "folders": sorted({entry["folder"] for entry in assets} | {""}),
         }
@@ -2019,12 +2124,24 @@ def create_app(
     async def input_file(
         name: str, request: Request, ws: Workspace = Depends(selected_workspace)
     ):
-        """One file from a workspace's asset library, for the editor's
-        preview of an uploaded or chosen asset."""
-        library = ws.assets
-        if not library:
+        """One file from the asset search path, for the editor's preview of
+        an uploaded or chosen asset - the workspace's own library first,
+        then any read-only examples library, so an example workflow's media
+        previews the way an upload does."""
+        roots = _asset_roots(ws)
+        if not roots:
             raise HTTPException(status_code=404, detail="No asset library")
-        files = _static_files_for(library)
+        for root in roots:
+            try:
+                candidate = validate_path(os.path.join(root, name), root)
+            except SecurityError:
+                continue
+            if os.path.isfile(candidate):
+                files = _static_files_for(root)
+                return await files.get_response(name, request.scope)
+        # Nothing has it: let the workspace's own library answer, so the
+        # 404 (and its headers) come from StaticFiles as they always did
+        files = _static_files_for(roots[0])
         return await files.get_response(name, request.scope)
 
     # ---------------------------------------------------------------- the UI

--- a/dw/workspace.py
+++ b/dw/workspace.py
@@ -246,6 +246,87 @@ def set_workspace(workspace):
     return workspace
 
 
+# Read-only libraries searched after the one a run writes to. A tree named
+# by --examples-dir brings the prompts and assets its workflows reference
+# along with it, and neither is reachable from the workspace's own library -
+# the search path is what closes that. Carried in the environment, joined by
+# os.pathsep, so a spawned worker inherits it the way it inherits
+# DW_PROMPT_DIR and DW_ASSET_DIR
+PROMPT_PATH_ENV_VAR = "DW_PROMPT_PATH"
+ASSET_PATH_ENV_VAR = "DW_ASSET_PATH"
+
+LIBRARY_PATH_ENV_VARS = {
+    PROMPTS_SUBDIR: PROMPT_PATH_ENV_VAR,
+    ASSETS_SUBDIR: ASSET_PATH_ENV_VAR,
+}
+
+
+def library_fallbacks(subdir, primary=None):
+    """The read-only roots a library is searched in after its own, in order.
+
+    Args:
+        subdir: 'prompts' or 'assets'
+        primary: The library that is searched first, dropped from the result
+            when it also appears here - a checkout serving as both the
+            workspace and the examples tree has one library, not two
+
+    Returns:
+        A list of absolute paths, each an existing directory
+    """
+    raw = os.environ.get(LIBRARY_PATH_ENV_VARS[subdir], "")
+    first = os.path.abspath(os.path.expanduser(str(primary))) if primary else None
+    roots = []
+    for entry in raw.split(os.pathsep):
+        if not entry.strip():
+            continue
+        root = os.path.abspath(os.path.expanduser(entry))
+        if root == first or root in roots or not os.path.isdir(root):
+            continue
+        roots.append(root)
+    return roots
+
+
+def set_library_fallbacks(subdir, roots):
+    """Pin a library's read-only roots in the environment, so the worker
+    subprocess resolves a reference exactly as the entry point would."""
+    joined = os.pathsep.join(
+        os.path.abspath(os.path.expanduser(str(root))) for root in roots or []
+    )
+    if joined:
+        os.environ[LIBRARY_PATH_ENV_VARS[subdir]] = joined
+    else:
+        os.environ.pop(LIBRARY_PATH_ENV_VARS[subdir], None)
+    return joined
+
+
+def example_libraries(examples_dirs):
+    """The prompt and asset libraries the trees named by --examples-dir
+    bring with them.
+
+    A workflows/ tree inside a checkout keeps the prompts and assets its
+    workflows reference beside it, so the sibling of each examples directory
+    is where they are; a directory that holds them itself - someone pointing
+    --examples-dir at a whole workspace - is checked first, and either can
+    be missing.
+
+    Args:
+        examples_dirs: The directories --examples-dir named, in order
+
+    Returns:
+        {'prompts': [roots], 'assets': [roots]}, deduplicated, in the order
+        the examples directories were given
+    """
+    found = {PROMPTS_SUBDIR: [], ASSETS_SUBDIR: []}
+    for directory in examples_dirs or []:
+        root = os.path.abspath(os.path.expanduser(str(directory)))
+        for holder in (root, os.path.dirname(root)):
+            for subdir in found:
+                candidate = os.path.join(holder, subdir)
+                if os.path.isdir(candidate) and candidate not in found[subdir]:
+                    found[subdir].append(candidate)
+    return found
+
+
 def discover_library(subdir, env_var, base_dir=None):
     """Where a shared library (prompts, assets) is rooted, by the precedence
     get_prompt_dir and get_asset_dir both need: an environment variable names

--- a/tests/test_library_sources.py
+++ b/tests/test_library_sources.py
@@ -1,0 +1,224 @@
+"""The prompt and asset search paths: an --examples-dir tree brings the
+prompts and media its workflows reference along with it, read-only, behind
+the workspace's own libraries."""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dw.assets import asset_search_path, resolve_asset_reference
+from dw.prompts import fetch_prompt, prompt_search_path, resolve_prompt_reference
+from dw.server.app import create_app
+from dw.server.jobs import JobManager
+from dw.workflow_sources import EXAMPLES_ORIGIN, WORKSPACE_ORIGIN
+from dw.workspace import (
+    ASSETS_SUBDIR,
+    PROMPTS_SUBDIR,
+    Workspace,
+    example_libraries,
+    library_fallbacks,
+    set_library_fallbacks,
+)
+
+from .test_server import ScriptedWorkerManager, success_script
+
+
+def write_prompt(directory, name, text):
+    path = os.path.join(directory, f"{name}.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as file:
+        json.dump({"text": text}, file)
+    return path
+
+
+@pytest.fixture
+def trees(tmp_path, monkeypatch):
+    """A workspace and a checkout beside it: the checkout's workflows/ is
+    what --examples-dir names, and its prompts/ and assets/ sit next to it."""
+    workspace = Workspace(tmp_path / "studio", "flag").ensure()
+
+    checkout = tmp_path / "repo"
+    (checkout / "workflows").mkdir(parents=True)
+    (checkout / "prompts" / "flux").mkdir(parents=True)
+    (checkout / "assets").mkdir(parents=True)
+    write_prompt(str(checkout / "prompts"), "flux/daffodil", "a biomechanical daffodil")
+    write_prompt(str(checkout / "prompts"), "shared", "the example's text")
+    (checkout / "assets" / "iris.png").write_bytes(b"example-png")
+    (checkout / "assets" / "shared.png").write_bytes(b"example-shared")
+
+    # No environment left over from another test, and none leaking out of this
+    for variable in ("DW_PROMPT_PATH", "DW_ASSET_PATH"):
+        monkeypatch.delenv(variable, raising=False)
+    return workspace, checkout
+
+
+class TestDerivation:
+    def test_the_libraries_beside_a_workflows_tree_are_found(self, trees):
+        _workspace, checkout = trees
+        found = example_libraries([str(checkout / "workflows")])
+        assert found[PROMPTS_SUBDIR] == [str(checkout / "prompts")]
+        assert found[ASSETS_SUBDIR] == [str(checkout / "assets")]
+
+    def test_a_directory_holding_them_itself_is_found(self, trees):
+        # --examples-dir pointed at a whole workspace rather than its
+        # workflows/ subfolder
+        _workspace, checkout = trees
+        found = example_libraries([str(checkout)])
+        assert found[PROMPTS_SUBDIR] == [str(checkout / "prompts")]
+
+    def test_a_tree_with_no_libraries_brings_none(self, tmp_path):
+        bare = tmp_path / "elsewhere" / "workflows"
+        bare.mkdir(parents=True)
+        found = example_libraries([str(bare)])
+        assert found == {PROMPTS_SUBDIR: [], ASSETS_SUBDIR: []}
+
+    def test_fallbacks_round_trip_through_the_environment(self, trees):
+        # This is how the worker subprocess learns them: spawn inherits the
+        # environment, it does not inherit the argument parser
+        _workspace, checkout = trees
+        set_library_fallbacks(PROMPTS_SUBDIR, [str(checkout / "prompts")])
+        assert library_fallbacks(PROMPTS_SUBDIR) == [str(checkout / "prompts")]
+
+    def test_the_primary_library_is_not_repeated_as_a_fallback(self, trees):
+        _workspace, checkout = trees
+        set_library_fallbacks(PROMPTS_SUBDIR, [str(checkout / "prompts")])
+        assert library_fallbacks(PROMPTS_SUBDIR, str(checkout / "prompts")) == []
+
+    def test_a_missing_root_is_dropped(self, tmp_path):
+        set_library_fallbacks(PROMPTS_SUBDIR, [str(tmp_path / "gone")])
+        assert library_fallbacks(PROMPTS_SUBDIR) == []
+
+
+class TestResolution:
+    @pytest.fixture(autouse=True)
+    def libraries(self, trees, monkeypatch):
+        workspace, checkout = trees
+        monkeypatch.setenv("DW_PROMPT_DIR", workspace.prompts)
+        monkeypatch.setenv("DW_ASSET_DIR", workspace.assets)
+        found = example_libraries([str(checkout / "workflows")])
+        monkeypatch.setenv("DW_PROMPT_PATH", os.pathsep.join(found[PROMPTS_SUBDIR]))
+        monkeypatch.setenv("DW_ASSET_PATH", os.pathsep.join(found[ASSETS_SUBDIR]))
+        return workspace, checkout
+
+    def test_the_workspace_comes_first_on_the_path(self, libraries):
+        workspace, checkout = libraries
+        assert prompt_search_path() == [workspace.prompts, str(checkout / "prompts")]
+        assert asset_search_path() == [workspace.assets, str(checkout / "assets")]
+
+    def test_an_example_prompt_resolves(self, libraries):
+        _workspace, checkout = libraries
+        assert fetch_prompt("prompt:flux/daffodil") == "a biomechanical daffodil"
+        assert resolve_prompt_reference("prompt:flux/daffodil") == os.path.realpath(
+            checkout / "prompts" / "flux" / "daffodil.json"
+        )
+
+    def test_an_example_asset_resolves(self, libraries):
+        _workspace, checkout = libraries
+        assert resolve_asset_reference("asset:iris.png") == os.path.realpath(
+            checkout / "assets" / "iris.png"
+        )
+
+    def test_the_workspace_shadows_the_example(self, libraries):
+        workspace, _checkout = libraries
+        write_prompt(workspace.prompts, "shared", "mine")
+        with open(os.path.join(workspace.assets, "shared.png"), "wb") as file:
+            file.write(b"mine")
+        assert fetch_prompt("prompt:shared") == "mine"
+        assert resolve_asset_reference("asset:shared.png").startswith(
+            os.path.realpath(workspace.assets)
+        )
+
+    def test_a_missing_name_names_every_root_it_looked_in(self, libraries):
+        workspace, checkout = libraries
+        with pytest.raises(ValueError) as error:
+            fetch_prompt("prompt:nowhere")
+        assert workspace.prompts in str(error.value)
+        assert str(checkout / "prompts") in str(error.value)
+
+
+class TestServer:
+    @pytest.fixture
+    def client(self, trees, tmp_path):
+        workspace, checkout = trees
+        write_prompt(workspace.prompts, "mine", "my own text")
+        with open(os.path.join(workspace.assets, "mine.png"), "wb") as file:
+            file.write(b"mine-png")
+        manager = JobManager(
+            workspace.outputs,
+            worker_manager=ScriptedWorkerManager(success_script),
+            history_path=str(tmp_path / "jobs.sqlite"),
+            workflow_dir=workspace.workflows,
+        )
+        app = create_app(
+            workflow_dir=workspace.workflows,
+            output_dir=workspace.outputs,
+            job_manager=manager,
+            prompt_dir=workspace.prompts,
+            asset_dir=workspace.assets,
+            examples_dirs=[str(checkout / "workflows")],
+            workspace=workspace.root,
+        )
+        with TestClient(app, base_url="http://localhost") as client:
+            yield client, workspace, checkout
+
+    def test_the_prompt_listing_spans_the_path(self, client):
+        api, workspace, checkout = client
+        body = api.get("/api/prompts").json()
+        assert set(body["prompts"]) == {"mine", "flux/daffodil", "shared"}
+        assert body["origins"]["mine"] == WORKSPACE_ORIGIN
+        assert body["origins"]["flux/daffodil"] == EXAMPLES_ORIGIN
+        assert body["prompt_dir"] == workspace.prompts
+        assert body["prompt_dirs"] == [workspace.prompts, str(checkout / "prompts")]
+        assert body["details"]["flux/daffodil"]["text"] == "a biomechanical daffodil"
+
+    def test_an_example_prompt_reads(self, client):
+        api, _workspace, _checkout = client
+        assert api.get("/api/prompts/flux/daffodil").json()["text"] == (
+            "a biomechanical daffodil"
+        )
+        assert api.get("/api/prompts/flux/daffodil/download").status_code == 200
+
+    def test_a_missing_prompt_is_still_a_404(self, client):
+        api, _workspace, _checkout = client
+        assert api.get("/api/prompts/nowhere").status_code == 404
+
+    def test_an_example_prompt_cannot_be_deleted(self, client):
+        api, _workspace, checkout = client
+        response = api.delete("/api/prompts/flux/daffodil")
+        assert response.status_code == 403
+        assert os.path.isfile(checkout / "prompts" / "flux" / "daffodil.json")
+
+    def test_saving_an_example_prompt_writes_a_copy(self, client):
+        api, workspace, checkout = client
+        saved = api.put(
+            "/api/prompts/flux/daffodil",
+            json={"prompt": {"text": "changed"}},
+        )
+        assert saved.status_code == 200
+        assert saved.json()["path"].startswith(os.path.abspath(workspace.prompts))
+        with open(checkout / "prompts" / "flux" / "daffodil.json") as file:
+            assert json.load(file)["text"] == "a biomechanical daffodil"
+        assert api.get("/api/prompts/flux/daffodil").json()["text"] == "changed"
+
+    def test_the_asset_listing_spans_the_path(self, client):
+        api, workspace, checkout = client
+        body = api.get("/api/assets").json()
+        origins = {entry["name"]: entry["origin"] for entry in body["assets"]}
+        assert origins == {
+            "mine.png": WORKSPACE_ORIGIN,
+            "iris.png": EXAMPLES_ORIGIN,
+            "shared.png": EXAMPLES_ORIGIN,
+        }
+        assert body["asset_dir"] == workspace.assets
+        assert body["asset_dirs"] == [
+            os.path.abspath(workspace.assets),
+            str(checkout / "assets"),
+        ]
+
+    def test_an_example_asset_is_served(self, client):
+        api, _workspace, _checkout = client
+        assert api.get("/inputs/iris.png").content == b"example-png"
+        assert api.get("/inputs/mine.png").content == b"mine-png"
+        assert api.get("/inputs/nothing.png").status_code == 404

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   ServerInfo,
   ValidationResult,
   WorkflowDefinition,
+  StoredPrompt,
   WorkflowWithOrigin,
 } from './types'
 import { getApiToken } from './token'
@@ -417,12 +418,26 @@ export const api = {
     ),
   listPrompts: () =>
     request<{
+      /** The writable library - where a save lands. */
       prompt_dir: string
+      /** The search path, writable library first. Absent from an older
+       * server, which had only the one. */
+      prompt_dirs?: string[]
       prompts: string[]
+      /** Which library each name came from: 'workspace' or 'examples'. */
+      origins?: Record<string, string>
       details: Record<string, PromptDetail>
     }>('/api/prompts'),
+  /** The prompt plus which library it came from, read off the response
+   * headers rather than a separate `listPrompts` lookup. */
   getPrompt: (name: string) =>
-    request<PromptDefinition>(`/api/prompts/${encodePath(name)}`),
+    fetchJson<PromptDefinition>(`/api/prompts/${encodePath(name)}`).then(
+      ({ body, response }): StoredPrompt => ({
+        prompt: body,
+        origin: response.headers.get('X-Prompt-Origin') ?? '',
+        writable: response.headers.get('X-Prompt-Writable') !== 'false',
+      }),
+    ),
   savePrompt: (name: string, prompt: PromptDefinition) =>
     request<{ name: string; path: string }>(
       `/api/prompts/${encodePath(name)}`,

--- a/ui/src/lib/pages/PromptEditorPage.svelte
+++ b/ui/src/lib/pages/PromptEditorPage.svelte
@@ -44,6 +44,10 @@
   let folder = $state('')
   let newFolder = $state('')
   let busy = $state(false)
+  // A prompt from a read-only examples library: it can be edited and saved
+  // (the save lands in this workspace's library, shadowing it) but not
+  // deleted, the way a read-only workflow behaves
+  let readOnly = $state(false)
   let baseline = $state('')
 
   // Existing folders, from the listing - one level is the designed depth
@@ -253,10 +257,14 @@
       folder = groupOf(name)
       api
         .getPrompt(name)
-        .then((definition) => {
-          doc = definition as PromptDefinition
-          baseline = JSON.stringify(definition)
-          idea = definition.enhanced?.idea ?? ''
+        // the definition comes back beside where it was found: a prompt
+        // from a read-only examples library can be edited and saved (the
+        // copy lands here) but not deleted
+        .then(({ prompt, writable }) => {
+          readOnly = !writable
+          doc = prompt
+          baseline = JSON.stringify(prompt)
+          idea = prompt.enhanced?.idea ?? ''
           preselect()
         })
         .catch((e) => notify.error(e.message))
@@ -495,13 +503,15 @@
       <Copy size={14} />Duplicate
     </button>
     <DownloadLink href={api.promptDownloadUrl(name)} />
-    <button
-      class="quiet withicon danger"
-      onclick={remove}
-      title="delete this prompt from the library"
-    >
-      <Trash2 size={14} />Delete
-    </button>
+    {#if !readOnly}
+      <button
+        class="quiet withicon danger"
+        onclick={remove}
+        title="delete this prompt from the library"
+      >
+        <Trash2 size={14} />Delete
+      </button>
+    {/if}
   {/if}
   <button
     class="withicon"

--- a/ui/src/lib/pages/PromptsPage.svelte
+++ b/ui/src/lib/pages/PromptsPage.svelte
@@ -9,6 +9,7 @@
 
   let prompts = $state<string[]>([])
   let details = $state<Record<string, PromptDetail>>({})
+  let origins = $state<Record<string, string>>({})
   let promptDir = $state('')
   let filter = $state('')
   let error = $state('')
@@ -20,6 +21,7 @@
       .then((result) => {
         prompts = result.prompts
         details = result.details ?? {}
+        origins = result.origins ?? {}
         promptDir = result.prompt_dir
         loaded = true
       })
@@ -82,6 +84,14 @@
       ></a>
       <span class="cardtop">
         <span class="cardname">{leafOf(name)}</span>
+        {#if origins[name] && origins[name] !== 'workspace'}
+          <span
+            class="origin muted"
+            title="read-only: from the {origins[name]} library"
+          >
+            {origins[name]}
+          </span>
+        {/if}
         {#if detail?.intended_model}
           <button
             class="chip modelchip"
@@ -122,6 +132,9 @@
 {/if}
 
 <style>
+  .origin {
+    font-size: 0.75rem;
+  }
   .head {
     display: flex;
     flex-wrap: wrap;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -105,6 +105,18 @@ export interface PromptDefinition {
   enhanced?: { model?: string; idea?: string }
 }
 
+/** A stored prompt plus which library it came from - `getPrompt` reads the
+ * two off the `X-Prompt-Origin` / `X-Prompt-Writable` response headers, the
+ * way `getWorkflow` reads a workflow's source. Beside the definition rather
+ * than spread into it: a prompt is saved back exactly as it was read, and a
+ * stray field would fail the schema. */
+export interface StoredPrompt {
+  prompt: PromptDefinition
+  /** 'workspace' | 'examples'. */
+  origin: string
+  writable: boolean
+}
+
 export interface PromptDetail {
   description: string
   intended_model: string


### PR DESCRIPTION
…port

- Introduced `prompt_search_path` and `asset_search_path` functions to manage search paths for prompts and assets, allowing read-only libraries from examples directories to be included.
- Updated `resolve_prompt_reference` and `resolve_asset_reference` to utilize the new search paths, ensuring correct resolution of prompts and assets.
- Modified the server API to return the origin of prompts and assets, indicating whether they are from the workspace or examples library.
- Adjusted the UI to reflect the read-only status of prompts from examples libraries, preventing deletion while allowing edits that save to the workspace.
- Added tests to verify the functionality of the new features, ensuring that prompts and assets from examples directories are correctly handled and resolved.