### PR TITLE
Part 4 design: catalog repair and plugin skills specs, with the H3 an…

### DIFF
--- a/docs/proposals/audits/2026-09-07-ltx-2.5-audit.md
+++ b/docs/proposals/audits/2026-09-07-ltx-2.5-audit.md
@@ -1,0 +1,244 @@
+# LTX-2.5 knowledge audit — `diffusers-workflow`
+
+Research date: 2026-09-07. Repo branch `agent-legibility`, ltx2 templates last touched 2026-09-07.
+Installed library: `diffusers 0.41.0.dev0` at
+`/Users/don/src/dkackman/diffusers-workflow/venv/lib/python3.14/site-packages/diffusers`.
+
+## Sources
+
+| URL | Type | Date | Contributes |
+| --- | --- | --- | --- |
+| `venv/.../diffusers/pipelines/ltx2/utils.py` (installed 0.41.0.dev0) | primary (library source) | as installed, read 2026-09-07 | `DISTILLED_SIGMA_VALUES` (8), `STAGE_2_DISTILLED_SIGMA_VALUES` (3), `DEFAULT_NEGATIVE_PROMPT`, `GEMMA4_PROMPT_ENHANCEMENT_CONFIG`, `LTX2_5_T2V/I2V_DEFAULT_SYSTEM_PROMPT`, CRF 18, `MAX_CONDITIONING_FPS=60` |
+| `venv/.../ltx2/pipeline_ltx2.py`, `_image2video.py`, `_condition.py`, `_ic_lora.py`, `_latent_upsample.py`, `_dfr.py` | primary (library source) | read 2026-09-07 | `__call__` defaults, `check_inputs` (w/h % 32), duration head, enhancer defaults, `LTX2VideoCondition`, `reference_downscale_factor` |
+| https://huggingface.co/Lightricks/LTX-2.5-Diffusers | primary | fetched 2026-09-07 (raw README 401 — gated; HTML card fetched OK) | Distilled recipe: sigmas + guidance 1.0/STG 0/modality 1.0; "half resolution, x2 latent upsample, then a 3-sigma tail at full resolution"; prompt-style statement; dedicated Gemma-4 enhancer; arXiv 2601.03233 |
+| https://huggingface.co/Lightricks/LTX-2.5 | primary | fetched 2026-09-07; release stated 2026-01-06 | `num_frames % 8 == 1`, w/h divisible by 32, 8-step distilled at CFG 1.0, component file list, upscalers |
+| https://huggingface.co/Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler | primary | fetched 2026-09-07 | Weight filename, LoRA strength 1.0, `reference_downscale_factor` 2, ~280p draft, "clean low-res render" requirement |
+| https://github.com/Lightricks/LTX-2 `README.md` (via `gh api`) | primary | fetched 2026-09-07 | Prompting section (≤200 words, single flowing paragraph, chronological, 7-part structure); DFR as production path; full model list; Gemma-4-12B fine-tuned encoder |
+| `.../LTX-2/packages/ltx-pipelines/docs/pipelines.md` | primary | fetched 2026-09-07 | DistilledPipeline = "two-stage, 8 predefined sigmas (8 steps stage 1, **4 steps stage 2**)"; DFR details; 8k+1 grid; DFR w/h % 64; fps snapping |
+| `.../LTX-2/packages/ltx-pipelines/docs/pipeline-selection.md` | primary | fetched 2026-09-07 | Pipeline decision tree; DistilledPipeline "starting point", DFR "production quality"; ICLoraPipeline for video conditioning |
+| `.../LTX-2/packages/ltx-pipelines/docs/conditioning.md` | primary | fetched 2026-09-07 | Image conditioning by replacing vs guiding latents; video conditioning listed ICLoraPipeline-only; generated keyframe slots |
+| `.../LTX-2/CHANGELOG.md` | primary | 1.2.0 dated **2026-08-11** ("Support for LTX 2.5"); 1.3.0 dated **2026-08-25** | Dates the LTX-2.5 tooling release; DFR, duration head, dedicated enhancer, NVFP4, HDR |
+| `.../LTX-2/packages/ltx-core/.../gemma4_t2v_system_prompt.txt` | primary | fetched 2026-09-07 | Byte-identical to diffusers' `LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT`; "roughly 150–220 words" |
+| `.../LTX-2/packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py` | primary | fetched 2026-09-07 | Upstream sigma lists (with trailing 0.0), CRF 33/18, stage-1 512x768 / stage-2 1024x1536, HQ 544x960, 121 frames @ 24 fps, guidance defaults |
+| https://huggingface.co/docs/diffusers/main/en/api/pipelines/ltx2 | primary (library docs) | fetched 2026-09-07 | Explicit two-stage code recipe incl. `noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0]` renoise before the 3-sigma tail; offload/tiling guidance |
+| https://runware.ai/docs/models/lightricks-ltx-2-5-pro/guides/prompting | secondary | model release date given as 2026-08-11 | Present tense; six-part scaffold in one flowing paragraph; audio integral; camera motion in its own clause; "no music" to suppress score |
+| https://ltx.io/blog/ltx-2-5-prompt-guide and /blog/prompting-guide-for-ltx-2 | secondary | — | **Fetch failed** (HTTP header overflow, both URLs). Content only reached indirectly via search snippets. |
+| WebSearch summaries (fal.ai, HackerNoon, Dream Pixel Forge, Prompt Architects, ltx.io excerpts) | secondary | 2026 | Restate the model card / GitHub README: single chronological paragraph, audio always described, dialogue in quotes, match length to complexity |
+| https://github.com/Lightricks/ComfyUI-LTXVideo `example_workflows/2.5/LTX-2.5_T2V_I2V_Two_Stage_Distilled.json` | primary (not fetched, surfaced by search) | 2026 | Corroborates 8 steps stage 1 → 2x upscale → +noise → 3 steps stage 2 |
+
+Note on secondary weight: every secondary prompting source found restates the GitHub README /
+model card almost verbatim (single flowing paragraph, chronological, ~200 words, describe audio).
+None contradicts a primary source, and none adds independent evidence. I therefore lean entirely on
+the primary system prompt text (`gemma4_t2v_system_prompt.txt`), which is the actual training-caption
+specification.
+
+---
+
+## Claim-by-claim verdict
+
+### `workflows/templates/ltx2/README.md`
+
+| Claim | Verdict |
+| --- | --- |
+| "LTX-2.5" is the model | **CONFIRMED** — `Lightricks/LTX-2.5-Diffusers` is the current Diffusers-format repo; LTX-2.5 released 2026-01-06, tooling support 2026-08-11 (LTX-2 CHANGELOG 1.2.0). |
+| Links "LTX-2.5" to `https://huggingface.co/Lightricks/LTX-Video` | **CONTRADICTED** — `LTX-Video` is the earlier, separate LTX-Video line. The LTX-2.5 repos are `Lightricks/LTX-2.5` (weights) and `Lightricks/LTX-2.5-Diffusers` (diffusers format). Wrong release entirely. |
+| Every table row links `LTX2.json`, `LTX2I2V.json`, `LTX2Keyframes.json`, `LTX2I2VEnhancePrompt.json`, `LTX2TwoStage.json`, `LTX2ICLora.json`, `LTX2Extend.json`, `LTX2I2VChained.json` | **CONTRADICTED by the repo itself** — none of those files exist. The eight files are `text-to-video.json`, `image-to-video.json`, `keyframes.json`, `enhance-prompt.json`, `two-stage.json`, `generative-upscale.json`, `extend-clip.json`, `chained-segments.json`. Those are the workflow `id`s, not paths. Every link in the reading-order map is broken. |
+| "fixed eight-step distilled schedule" | **CONFIRMED** — `DISTILLED_SIGMA_VALUES` has 8 entries (upstream's 9 includes the trailing 0.0 that the scheduler appends); pipelines.md: "8 predefined sigmas (8 steps in stage 1…)". |
+| "quantized per component" | Repo-specific engineering; sources are silent (they document `--quantization fp8-cast` / `nvfp4-*`, not SDNQ). **UNSOURCED**, not contradicted. |
+| "VAE tiling for the longer clip" | **CONFIRMED** — diffusers docs recommend `pipe.vae.enable_tiling()` for high resolution; the conv VAE is the only decoder that tiles. |
+| Two-stage is "the recommended quality flow" | **PARTLY CONTRADICTED** — as of LTX-2 1.2.0 (2026-08-11) the recommended *quality* path is `DFRPipeline`; DistilledPipeline's two-stage is described as the "fastest inference … starting point". And the repo's two-stage omits stage 2 (see below). |
+| IC-LoRA is "a generative 2x upscale … inventing detail" | **CONFIRMED** — the IC-LoRA card uses almost exactly that language ("re-rendering the scene at higher resolution, inventing plausible fine detail"). |
+| Extend "conditioning on it in full" | **CONFIRMED as mechanically valid** by `LTX2VideoCondition` ("a single frame or a sequence of frames"). Lightricks' own `conditioning.md` restricts whole-video conditioning to `ICLoraPipeline`, so the flow is a diffusers capability rather than a documented Lightricks recipe. **UNSOURCED as a recommendation.** |
+| Chained segments on last frame | Repo engine feature (`chain`, `trim_frames`, `crossfade_ms`). **UNSOURCED** — no Lightricks guidance either way. Note upstream would reach the same goal with the duration head (up to 20 s) or DFR. |
+
+### Shared template settings (all eight)
+
+| Claim | Verdict |
+| --- | --- |
+| `sigmas: constant:…DISTILLED_SIGMA_VALUES`, no `num_inference_steps` | **CONFIRMED** — model card: "No `num_inference_steps` parameter; use explicit sigma schedule instead"; `sigmas=DISTILLED_SIGMA_VALUES` (required for quality). |
+| `guidance_scale: 1.0`, `audio_guidance_scale: 1.0` | **CONFIRMED** — model card lists exactly these for the distilled transformer. |
+| `stg_scale: 0.0`, `audio_stg_scale: 0.0` | **CONFIRMED** — model card. |
+| `modality_scale: 1.0`, `audio_modality_scale: 1.0` | **CONFIRMED** — model card. |
+| `negative_prompt: constant:…DEFAULT_NEGATIVE_PROMPT` | **CONFIRMED** — the diffusers constant carries an upstream provenance comment pointing at `ltx-pipelines` `constants.py`. Note upstream's own current default begins `has_subtitles, has_blurbox, transition from black…`, so the two lists have drifted; the diffusers copy is pinned to commit `ae855f8`. Minor, low-risk. |
+| `frame_rate: 24.0` / `result.fps: 24` | **CONFIRMED** — 24 fps is the documented default; the transformer is trained around 24/25/30 and 60. |
+| `num_frames` values 121, 241, 481 | **CONFIRMED** — all satisfy `8k+1` (`num_frames % 8 == 1`), the VAE temporal grid. 121 ≈ 5.04 s at 24 fps. |
+| Resolutions 960x544, 768x448, 768x768, 480x288, 960x576 | **CONFIRMED** — every one is divisible by 32, the documented spatial rule. 544x960 is upstream's named HQ stage-1 preset. |
+| `torch_dtype: torch.bfloat16` throughout | **CONFIRMED** — bf16 is the published weight dtype and the recommended runtime dtype. |
+| `text_encoder` = `transformers.Gemma4UnifiedForConditionalGeneration` from the LTX-2.5 repo's `text_encoder` subfolder | **CONFIRMED** — Gemma 4 12B, fine-tuned for LTX, bundled; the README warns stock Google Gemma 4 is *not* a substitute (version check against `gemma4-12b-ltx-v1`). |
+| `duration_head` component present | **CONFIRMED** — LTX-2.5 addition (CHANGELOG 1.2.0, 2026-08-11). |
+| SDNQ uint4 transformer / int8 text encoder, `group_offload leaf_level use_stream` | **UNSOURCED** — Lightricks documents fp8-cast / NVFP4 / `--offload cpu|disk`; SDNQ and diffusers group-offload are outside their guidance. Not contradicted, but nothing upstream validates uint4 for the 22B distilled transformer. |
+
+### `text-to-video.json` (id `LTX2`)
+
+- Everything above: **CONFIRMED**.
+- Description "The distilled transformer runs a fixed eight-step schedule with guidance off": **CONFIRMED**.
+- Default prompt `prompt:ltx2/fox_dawn_choir`: **CONTRADICTED as prompt style** — see the prompt section below.
+- 960x544 as the base resolution: **CONFIRMED** as a tested/HQ-preset stage-1 size.
+
+### `image-to-video.json` (id `LTX2I2V`)
+
+- `LTX2ImageToVideoPipeline`, 768x768, 481 frames (20 s at 24 fps): **CONFIRMED** as legal (768 % 32 = 0; 481 = 8·60+1; 20 s is the enhancer/duration-head upper bound).
+- **UNSOURCED / worth flagging**: the pipeline re-compresses a single-frame image conditioning at H.264 CRF **18** for LTX-2.5 (`resolve_default_image_crf`) to match training compression, and this requires a `PIL.Image.Image` plus PyAV — otherwise `check_inputs` raises. The repo carries no note of this anywhere.
+- No mention that an already-compressed / degraded input still gets re-compressed. Not an error, but undocumented.
+
+### `keyframes.json` (id `LTX2Keyframes`)
+
+- `LTX2ConditionPipeline` with two `LTX2VideoCondition`s at `index: 0` and `index: -1`, `strength: 1.0`: **CONFIRMED** by the diffusers source and the docs page ("arbitrary latent frame conditioning (FLF2V, etc.)").
+- `strength: 1.0` for both endpoints: **CONFIRMED as the meaning** ("fully applied"). Lightricks' `conditioning.md` distinguishes *replacing* latents (strong control) from *guiding* latents ("better for smooth interpolation between keyframes") — for a first/last-frame interpolation their guidance leans toward the guiding variant, i.e. a strength below 1.0 on the endpoints. Compare `ANCHOR_KEYFRAME_STRENGTH = 0.95` in `utils.py`, used for exactly this reason ("pinned just short of fully clean so a tile can still settle its seam frame"). **Not contradicted, but arguably the wrong end of the range.**
+- Uses `flf2v_input_first/last_frame.png` from the HF docs-images dataset — those are Wan FLF2V demo assets, unrelated to LTX. Cosmetic.
+
+### `enhance-prompt.json` (id `LTX2I2VEnhancePrompt`)
+
+- Dedicated `prompt_enhancer` = `google/gemma-4-E2B-it` with `AutoProcessor`, separate from the text encoder: **CONFIRMED** — model card: "a dedicated `google/gemma-4-E2B-it` `prompt_enhancer` component (the fine-tuned text encoder isn't trained for enhancement)"; CHANGELOG 1.2.0 added `--prompt-enhancer-gemma-root`.
+- `enable_prompt_enhancement: true` with no `system_prompt`: **CONFIRMED correct** — `pipeline_ltx2_image2video.py:1270` defaults to `LTX2_5_I2V_DEFAULT_SYSTEM_PROMPT`, which is byte-identical to upstream `gemma4_i2v_system_prompt.txt`.
+- `prompt_max_new_tokens: constant:…GEMMA4_PROMPT_ENHANCEMENT_CONFIG.max_new_tokens` (600): **CONFIRMED but redundant** — the pipeline selects that config automatically when a dedicated enhancer is present (`pipeline_ltx2_image2video.py:603`).
+- Does **not** pass `prompt_enhancement_kwargs`: **CONFIRMED harmless** — defaults resolve to `{"do_sample": False, "no_repeat_ngram_size": 5}` from the same config.
+- Enhancer on `device: "cpu"` with `uint4` SDNQ: **UNSOURCED**; a 2B enhancer at uint4 on CPU is an aggressive combination for a component whose whole job is careful long-form generation. Nothing upstream speaks to it.
+- Duration head via `min_seconds: 2.0` / `max_seconds: 8.0`: **CONFIRMED** as a legal range (pipeline defaults 1.0/20.0; `min < max` enforced). Predicted counts snap to the 8k+1 grid (~0.33 s at 24 fps).
+- README's claim that the enhancer "rewrites a one-line idea into a trained-format prompt": **CONFIRMED** — that is precisely what `LTX2_5_I2V_DEFAULT_SYSTEM_PROMPT` instructs (150–220 words, single paragraph, framing triple, integrated soundscape).
+
+### `two-stage.json` (id `LTX2TwoStage`) — the biggest gap
+
+- Claimed as "LTX-2.5's recommended quality flow: render small, then upscale in latent space rather than at full size."
+- Implemented as: base 768x448 (8 sigmas) → `LTX2LatentUpsamplePipeline` → `pair_audio`.
+- **CONTRADICTED.** Every primary source describes the distilled two-stage as *three* moves, not two:
+  - LTX-2.5-Diffusers model card: "half resolution, x2 latent upsample, **then a 3-sigma tail at full resolution**" — "Stage 2 decoding with `STAGE_2_DISTILLED_SIGMA_VALUES`".
+  - `pipelines.md` §4 DistilledPipeline: "Two-stage generation with 8 predefined sigmas (**8 steps in stage 1, 4 steps in stage 2**)." (Upstream's 4-value stage-2 list includes the trailing 0.0; diffusers' 3-value constant is the same schedule.)
+  - diffusers docs page gives the code: re-enter the *same* pipeline with `latents=upscaled_video_latent`, `audio_latents=audio_latent`, `sigmas=STAGE_2_DISTILLED_SIGMA_VALUES`, and crucially `noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0]` to renoise before denoising.
+  - ComfyUI-LTXVideo's own `LTX-2.5_T2V_I2V_Two_Stage_Distilled.json` example corroborates.
+  - `STAGE_2_DISTILLED_SIGMA_VALUES` exists in the installed `utils.py` and is referenced **nowhere else in diffusers** — it is there for callers to use, and the repo never uses it.
+- Consequence: the repo's "two-stage" is a bare latent upsample with no refinement pass. The upsampler alone produces a soft 2x; the detail is supposed to come from the 3-sigma tail. The claim that the result "is sharper than a single pass at 1536x896" (RECIPES_24GB) is therefore **UNSOURCED and probably false as built**.
+- Also **CONTRADICTED**: the flow's framing as the *recommended quality* path. Since 2026-08-11, Lightricks route production quality to `DFRPipeline` (`LTX2DFRPipeline` exists in the installed diffusers), which is stage 1 at half res + generated keyframe slots + a full-res detailing pass with the same IC-LoRA. The repo ships neither.
+- `pair_audio` re-attaching stage-1 audio: **CONFIRMED as the right instinct** — "Audio comes from stage 1… nothing refines audio after stage 1." But the correct implementation carries `audio_latents` into stage 2 so video↔audio cross-attention still has a stream; muxing the decoded soundtrack afterwards is a reasonable substitute only because there is no stage 2 here.
+- `adain_factor: 0.0`, `tone_map_compression_ratio: 0.0` (both library defaults, i.e. off): **CONFIRMED as defaults**; no source recommends nonzero.
+- Passing the *input* (base) `width`/`height` to the upsampler: **CONFIRMED correct** — the docstring says these are "the input video (not the generated video, which will have a larger resolution)".
+- Passing `video=` pixels rather than `latents=`: **CONTRADICTED as best practice** — the diffusers recipe keeps stage 1 at `output_type="latent"` and hands latents straight across; the repo decodes to pixels and re-encodes, a lossy round trip through the VAE for no benefit.
+
+### `generative-upscale.json` (id `LTX2ICLora`)
+
+- LoRA repo, weight filename `ltx-2.5-22b-ic-lora-pixel-spatial-upscaler-x2-1.0.safetensors`, `scale: 1.0`: **CONFIRMED** exactly by the IC-LoRA model card ("LoRA strength 1.0, pre-scaled default") and the LTX-2 README download command.
+- `reference_downscale_factor: 2`: **CONFIRMED** — card gives 2.
+- `conditioning_attention_strength: 1.0`: **CONFIRMED as the library default**; card is silent.
+- Base 480x288 → 960x576: **CONFIRMED and well-aimed** — the card names "~280p (draft generation)" as the base and 2x the reference as output. 288p is a good read of that.
+- `reference_conditions` with `LTX2ReferenceCondition(frames=…, strength=1.0)`: **CONFIRMED** by the diffusers `pipeline_ltx2_ic_lora.py` example.
+- Card note "fewer steps and lower guidance keep output closer to reference; more steps and higher guidance allow more creative hallucination" — the repo pins the 8-sigma distilled schedule at guidance 1.0 and offers no variable for this trade-off. **Missing knowledge**, not an error.
+- Card note "reference should be a clean low-resolution render, not heavily compressed or degraded" — satisfied here (the reference is the in-memory stage-1 output), but not stated anywhere in the repo, so a user pointing this at a downloaded clip gets no warning.
+- **Engineering flag (not a knowledge claim):** step 2 `reused_components` the transformer from step 1 and then loads a LoRA onto it. Whether the shared transformer is mutated for anything downstream depends on the engine; worth a look, but out of scope here.
+
+### `extend-clip.json` (id `LTX2Extend`)
+
+- `LTX2ConditionPipeline`, whole 121-frame opening as one condition at `index: 0`, `strength: 1.0`, `num_frames: 241`: **mechanically CONFIRMED** by `LTX2VideoCondition` (accepts a frame sequence) and by the docstring note "Multi-frame video conditions are not re-compressed."
+- As a *recommended* extend recipe: **UNSOURCED**. Lightricks has no "extend" pipeline; `conditioning.md` scopes whole-video conditioning to `ICLoraPipeline`, and the nearest documented equivalent for making a longer clip is the duration head (to 20 s) or `RetakePipeline` for regenerating a region. Nothing contradicts the flow; nothing endorses it either.
+- Two prompts (opening + continuation): sensible, unsourced.
+
+### `chained-segments.json` (id `LTX2I2VChained`)
+
+- Repo engine feature end to end (`chain.continuity: last_frame`, `trim_frames: 2`, `crossfade_ms: 80`). **UNSOURCED** in all Lightricks material.
+- Worth noting against a primary source: each segment's start frame is a single image conditioning, so each segment pays the CRF-18 re-compression, and the LTX-2.5 duration head plus a 481-frame single pass (already used in `image-to-video.json`) reaches 20 s without stitching. The chain earns its place only past that.
+
+### Prompt style — `prompts/ltx2/*.json` (used as every template's default)
+
+This is where the repo diverges most from primary guidance.
+
+Lightricks' training-caption specification (`gemma4_t2v_system_prompt.txt`, byte-identical to
+`LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT` in the installed diffusers) requires:
+
+1. Begin immediately with the action — never "The scene opens…", "We see…", "There is…".
+2. Objective, observable description only; no inferred emotion.
+3. Full visual detail: environment materials/textures/lighting/colors, character appearance, spatial positions.
+4. A **framing triple woven into prose** for every shot: shot type (one of six named sizes), camera motion (always stated, explicitly "static" if none), and viewpoint relative to subject.
+5. Complete soundscape integrated **chronologically alongside the action**, not appended.
+6. Strict chronological real-time flow with connectors ("Initially…", "A moment later…", "Simultaneously…").
+7. **One continuous paragraph, roughly 150–220 words.** No labels, no bullets.
+   Dialogue quoted exactly. Present-progressive verbs.
+
+Against that:
+
+| Prompt | Words | Verdict |
+| --- | --- | --- |
+| `fox_dawn_choir` (default of `text-to-video.json`, `two-stage.json`) | ~35 | **CONTRADICTED**. Far under 150–220. Worse, it ends with tag-style modifiers — "cinematic lighting, 8k, ultra-detailed, photorealistic in the distance" — which is Stable-Diffusion-era booru style, not a caption. The training spec explicitly wants quality descriptors "woven naturally into the same observable prose", never as tags. The trailing "in the distance" is also a dangling fragment. No shot type, no camera-motion statement, no viewpoint. |
+| `hummingbird_garden` (`generative-upscale.json`) | ~34 | **CONTRADICTED** — too short; no framing triple; audio is a separate trailing sentence rather than integrated chronologically. |
+| `lighthouse_keeper` (`extend-clip.json`) | ~35 | **CONTRADICTED** — same shape. |
+| `lighthouse_keeper_gallery` | ~55 | **CONTRADICTED** — closer (has a chronological "then", quoted dialogue "still burning" ✓) but still ~1/3 the target length, no framing triple. |
+| `marmot_robot_overlords` (`image-to-video.json`, `chained-segments.json`) | ~90 | **Partly CONFIRMED, partly CONTRADICTED**. Best of the set: quoted dialogue ✓, present tense ✓, detailed environment ✓, subject appearance ✓. But it *is* an I2V prompt and the I2V spec says "describe only changes from the image; don't reiterate established visual details" — this reiterates them at length. It also has zero audio beyond the sung line, no camera-motion statement, and closes with image-generation vocabulary ("The image is highly detailed, with realistic textures and vibrant colors") — "image", not video, and "vibrant colors" is exactly the intensified-color phrasing the spec forbids ("Use plain terms ('red dress'), not intensified"). |
+| `polaroid_lighthouse` (`keyframes.json`) | ~50 | **CONTRADICTED** on length and framing triple; the audio ("gulls call overhead") is appended rather than interleaved. |
+
+Also: `"intended_model": "ltx-2"` on all six, and several template `summary` fields say "LTX-2" where
+the workflows target LTX-2.5. **Minor CONTRADICTION** — LTX-2, LTX-2.3 and LTX-2.5 are distinct
+releases with different text encoders (Gemma 3 vs Gemma 4) and different image-conditioning CRF.
+
+`enhance-prompt.json`'s inline default `"a marmot in a top hat and monocle sings to the camera"` is
+**CONFIRMED correct** for its purpose — the enhancer's whole job is to take a one-line idea, so a short
+prompt is right *there* and only there.
+
+### `docs/RECIPES_24GB.md` LTX-2.5 section
+
+| Claim | Verdict |
+| --- | --- |
+| Per-component placement rather than a pipeline-level `offload` | **UNSOURCED** (repo engineering); not contradicted. |
+| "`transformer` is the distilled model… fixed 8-step schedule at `guidance_scale: 1.0`, STG and modality guidance off, and the `sigmas`… are its trained schedule — not a knob" | **CONFIRMED**, and well put. |
+| "`num_inference_steps`, `guidance_scale`, `stg_scale` and the rest only mean anything against `subfolder: "transformer_full"`, the dev model" | **CONFIRMED in substance** — the dev/full 22B transformer is what the guided TI2Vid/Keyframe/A2Vid pipelines take, at 30 steps / CFG 3.0 / STG 1.0 / modality 3.0 / rescale 0.7 / STG block 28 (or 29 in `constants.py`). The specific subfolder name `transformer_full` I could not verify against the gated Diffusers repo file listing — **UNVERIFIED**. |
+| "the same ~38GB in bf16" for the dev transformer | 22B at bf16 ≈ 44GB; the cards say 22B (the Diffusers card page also says 19B, which is stale/2.3-era). **UNVERIFIED / likely off**. |
+| "the checkpoint ships a diffusion decoder that `LTX2Pipeline` ignores" | **CONFIRMED** — LTX-2.5 ships both a `NADiffusionDecoder` video VAE and a conv variant; only the conv one tiles; `LTX2VideoDiffusionDecodePipeline` is the way to reach the diffusion decoder. |
+| "70GiB at 1536x896x121, which no tile size reduces" and "a step that returns latents returns audio latents too, which nothing outside a pipeline call can vocode" | **UNSOURCED** but internally consistent and clearly measured locally. Upstream's answer to the same problem is different: keyframe-aware decode + `AUTO_TILING` (CHANGELOG 1.3.0, 2026-08-25), and installing the `natten` extra. **Missing knowledge.** |
+| "Spend headroom on the two-stage flow rather than on base resolution: render at 768x448, upsample the latents 2x, and the result is sharper than a single pass at 1536x896" | **CONTRADICTED / incomplete** — as implemented there is no stage-2 refinement, so the sharpness claim is unsupported. With the 3-sigma tail it would be defensible. |
+| Example links | All eight file paths here are **correct** (unlike the template README). |
+
+### `docs/ACCELERATION.md` / `docs/QUANTIZATION.md`
+
+- ACCELERATION's note that LTX-2's blocks return two hidden-state streams and need extra cache metadata beyond diffusers' defaults: **UNSOURCED** upstream (it's a diffusers-internals observation), not contradicted.
+- QUANTIZATION's "the pattern the LTX-2 and MiniMax H3 [workflows use]": repo-internal. Fine.
+- Neither doc mentions `torch.compile` / CUDA-graph capture, FP8 or NVFP4 for LTX-2.5, all of which upstream documents (CHANGELOG 1.2.0/1.3.0). **Missing knowledge**, CUDA-only.
+
+---
+
+## Missing knowledge
+
+Recommendations the sources make that the repo does not carry, newest first.
+
+1. **The stage-2 refinement tail (dated: on the LTX-2.5-Diffusers card and `pipelines.md`; ComfyUI example workflow; diffusers docs page — all current as of 2026-09-07).** Renoise the upsampled latent with `noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0]` and run 3 more steps at `sigmas=STAGE_2_DISTILLED_SIGMA_VALUES` through the same pipeline, carrying `audio_latents` across. This is *the* defining half of the distilled two-stage recipe and the repo has none of it.
+2. **`DFRPipeline` — the current production-quality path (added 2026-08-11, CHANGELOG 1.2.0; refined 2026-08-25, 1.3.0).** `LTX2DFRPipeline` and `LTX2DFRTemporalRefinePipeline` are already present in the installed diffusers and unused. It is stage 1 at half res with generated keyframe slots, then a full-res detailing pass with the same IC-LoRA the repo already downloads. Its rules differ: **w/h divisible by 64** (128 with `--spatial-upscalings 2`), 4K is `3840x2176` not `3840x2160`, defaults 1024x1536 at 24 fps.
+3. **Temporal upscaling for higher frame rates (2026-08-11, renamed `--temporal-upscalings` 2026-08-25).** 0/1/2 rounds → 121/241/481 frames at 24/48/96 fps for the same ~5 s. Requires `ltx-2.5-latent-temporal-upscaler-x2-bf16-1.0.safetensors`, which the repo never mentions.
+4. **The fps trap (documented in the installed `utils.py`, `MAX_CONDITIONING_FPS` / `SNAP_CONDITIONING_FPS_ABOVE`, and in `pipelines.md`).** RoPE time is `pixel_frame / fps`; the transformer is trained around 24/25/30/60. 120 fps decodes as a motion spike per latent border then a stall; 48 stretches the other way. Condition at 60 and treat the frames at playback rate. The repo hardcodes 24 everywhere so it never hits this — but an agent composing from the repo's knowledge has no guardrail if a user asks for 60 fps. Also: some players read 96 fps H.264 as 24 and play in slow motion.
+5. **Generated keyframe slots (2026-08-11).** Extra fully-denoised single-pixel-frame slots at interior positions, relaxing effective temporal compression where motion is too fast for the base grid. Available on `DistilledPipeline` stage 1. Costs ~+16% tokens for 5 slots at 512x768x241. This is the documented answer to fast-motion smearing, and the repo has no notion of it.
+6. **Image-conditioning CRF (LTX-2.5 = 18, earlier = 33).** Auto-resolved from the text encoder's `model_type`, requires a PIL image and PyAV or `check_inputs` raises. Multi-frame video conditions are exempt. Undocumented in the repo despite three image-conditioned templates.
+7. **Prompting: the actual training-caption spec.** The repo carries no prompting guidance at all — no `prompts/ltx2/README`, nothing in the templates' README, nothing in WORKFLOW_GUIDE for LTX. The full spec is sitting in the installed `utils.py` as `LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT` / `LTX2_5_I2V_DEFAULT_SYSTEM_PROMPT` and could simply be pointed at.
+8. **The I2V-specific prompting rule.** "Describe only changes from the image; don't reiterate established visual details. Inaccurate descriptions may cause scene cuts." The repo's I2V prompt does the opposite.
+9. **IC-LoRA trade-off knob.** Fewer steps / lower guidance → closer to reference; more → more hallucination. And: the reference must be a clean low-res render, not compressed footage. Not for live-action fidelity work.
+10. **Keyframe strength below 1.0** for smooth interpolation (`conditioning.md`'s "guiding latents"; cf. `ANCHOR_KEYFRAME_STRENGTH = 0.95`).
+11. **Upstream memory tooling the repo doesn't discuss (2026-08-11 / 2026-08-25):** NVFP4 (`nvfp4-cast` / `nvfp4-prequant`, Blackwell + `ltx-kernels`), `fp8-cast`, `--offload cpu|disk`, CUDA-graph capture with `max_video_tokens`/`max_audio_tokens`, `AUTO_TILING` and keyframe-aware DiffVAE decode with the `natten` extra. Several are CUDA/Blackwell-only, but the repo's 24GB recipe is the natural place for at least fp8.
+12. **HDR / EXR conditioning and output (2026-08-11)**, `HDRICLoraPipeline`, `--hdr`. `pipeline_ltx2_hdr_lora.py` is installed and unused.
+13. **`RetakePipeline`** — regenerate a time region of an existing video; the documented "edit a clip" answer, distinct from the repo's extend/chain flows.
+14. **Multishot generation** — the LTX-2.5 card names "native multishot… connected scenes in a single pass" as a headline capability, with its own prompting guidance. Nothing in the repo.
+
+---
+
+## Assessment
+
+The repo's *mechanical* LTX-2.5 knowledge is unusually good. Everything that touches the distilled
+schedule is right and right for the right reason: the 8-sigma constant referenced rather than copied,
+`guidance_scale` 1.0 with STG and modality guidance zeroed, no `num_inference_steps`, `8k+1` frame
+counts, resolutions on the 32-pixel grid, 24 fps, the dedicated Gemma-4 enhancer with its own config,
+the IC-LoRA's filename / strength 1.0 / `reference_downscale_factor` 2 / ~280p draft. RECIPES_24GB's
+distilled-vs-dev explanation is better than most of what is written about this model publicly. I would
+trust all of that in a skill.
+
+Two things need correction before it teaches anything.
+
+**The two-stage flow is missing its second stage.** Every primary source describes it as 8 sigmas at
+half res → 2x latent upsample → **renoise and 3 more sigmas at full res**. The repo upsamples and
+stops, then calls the result the recommended quality flow and claims it beats a full-res single pass.
+`STAGE_2_DISTILLED_SIGMA_VALUES` sits unused in the installed library. It also decodes to pixels
+between the stages instead of passing latents. Separately, since 2026-08-11 the *recommended* quality
+path is `DFRPipeline`, which is installed and unused.
+
+**The prompt library is the wrong genre.** LTX-2.5 was trained on 150–220-word single-paragraph
+audio-visual captions carrying an explicit shot-type / camera-motion / viewpoint triple in prose and
+a soundscape interleaved chronologically with the action. Five of six stored prompts are 35–55 words,
+none states a shot type or camera motion, audio is appended rather than woven, and two end in
+Stable-Diffusion tag style ("8k, ultra-detailed", "vibrant colors") that the spec explicitly forbids.
+An agent taught to write LTX prompts from these examples would write bad ones. The correct spec is
+already on disk in `utils.py`.
+
+Smaller: the template README links eight filenames that do not exist and points "LTX-2.5" at the
+LTX-Video repo; prompts and summaries say "ltx-2" for a 2.5-only model.

--- a/docs/proposals/audits/2026-09-07-minimax-h3-audit.md
+++ b/docs/proposals/audits/2026-09-07-minimax-h3-audit.md
@@ -1,0 +1,339 @@
+# MiniMax-H3 knowledge verification — diffusers-workflow
+
+Research date: 2026-09-07. Repository branch `agent-legibility`, commit b2b9a8b.
+No repository file was modified.
+
+## Headline
+
+MiniMax publishes two official prompt-writing guides and an official
+`h3-prompt-writing` Skill. The repository's `dw/workflows/h3_context_ir.json`
+system prompt is, to a very high degree, a **faithful and compressed
+transcription of those two guides** — most sentences are near-verbatim. The
+gaps are omissions rather than errors, plus one wholly invented layer
+("continuity modes"). The `workflows/templates/minimax/README.md` numeric
+conventions check out against the installed diffusers source.
+
+---
+
+## Sources
+
+| URL | Type | Date | Contributes |
+| --- | --- | --- | --- |
+| https://huggingface.co/MiniMaxAI/MiniMax-H3/raw/main/README.md | PRIMARY | model card, current as fetched 2026-09-07 | Output specs (4–15 s, 24 fps, 32 kHz stereo, 768p default / 2K, 11 languages, aspect ratios), variant/input limits (≤9 images, ≤3 videos, ≤3 audio, ≤12 files), three-module system (Context-IR / Base / Regenerate-2K), CFG-distilled checkpoints, three worked Context-IR outputs (T2VA, I2VA, Ref2VA) as real reference prompts, links to the prompting guides and skills |
+| https://huggingface.co/MiniMaxAI/MiniMax-H3/raw/main/docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md | PRIMARY | shipped with the model card | **The** spec for T2VA/I2VA/FL2VA/L2VA: instruction-block sentences verbatim, three core fields, shot/cut rules, the full camera-motion table, speaker IDs, `<d>`/voiceover/`<scenetrans>`/`<cutoff>`, on-screen text, `overall_soundscape` / `non_diegetic_music` rules, four cases |
+| https://huggingface.co/MiniMaxAI/MiniMax-H3/raw/main/docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md | PRIMARY | shipped with the model card | **The** spec for Ref2VA: six sections and their order, the four label types, `summary` task-type table, `retention_analysis` marker tables, `detailed_description` rules incl. 350–500 words, speaker/audio-source rules, complete example |
+| https://github.com/MiniMax-AI/MiniMax-H3 (`skills/h3-prompt-writing/`) | PRIMARY | last commit touching skills 2026-08-15 (`d21241f`); "Tips for better results" added 2026-08-11 (`a107547`) | Official agent-facing Skill wrapping the two guides; adds duration-matching and label-consistency tips; `references/base-en.txt` and `ref-en.txt` are the same guides |
+| https://platform.minimax.io/docs/api-reference/video-generation-v2-h3-context-ir | PRIMARY | fetched 2026-09-07 | Hosted Context-IR endpoint: duration 4–15 (integer), ratio vocabulary, per-modality file limits; **no continuation/extension mode exists** |
+| diffusers 0.41.0.dev0, `modular_pipelines/minimax_h3/` (installed in repo venv) | PRIMARY | as installed | `MINIMAX_H3_FPS = 24`, `min_duration = 5.0`, `max_duration = 15.0`, `align_num_frames` (`17n + 5`), canvas rules (multiple of 32, short edge 768, max 768×1344, aspect 1:4–4:1), `reference_image_short_edge = 2048`, reference caps |
+| diffusers 0.41.0.dev0, `modular_pipelines/minimax_music3/` | PRIMARY | as installed | `audio_duration` = "Upper bound on the generated audio length… The language model may stop earlier. Capped at 9000 frames (six minutes)" |
+| https://huggingface.co/docs/diffusers/main/en/api/pipelines/minimax_h3 | PRIMARY | main branch, fetched 2026-09-07 | "24 fps, 5 to 15 seconds", `17n+5`, 768 short edge, guidance-distilled (no `guidance_scale`, no `negative_prompt`), `num_inference_steps` counts sigma grid points incl. terminal 0, reference ordering is semantic, 960×544 endorsed as the speed lever |
+| https://github.com/ModelTC/Minimax-H3-Turbo (README) | PRIMARY (LoRA author) | repo README as fetched 2026-09-07 | Turbo LoRA spec table: task, training resolution, video/audio shifts, distillation NFE, recommended NFE; reference-resize policies (`match` / `max` / `diffusers`) and the recommendation to use `match` |
+| https://huggingface.co/api/models/lightx2v/Minimax-h3-Turbo | PRIMARY | `lastModified` 2026-09-04, created 2026-08-07 | Actual file list — includes files newer than the ModelTC README table |
+| https://huggingface.co/MiniMaxAI/MiniMax-Music3/raw/main/README.md | PRIMARY | fetched 2026-09-07 | Music3 usage; only shows `audio_duration=60.0`, no ceiling semantics stated |
+| https://docs.comfy.org/tutorials/video/minimax/minimax-h3 | SECONDARY (vendor-adjacent, cited by the LoRA authors) | fetched 2026-09-07 | Reference tagging "in the exact order it was connected"; explicit role assignment advice; 20 steps default / ~25 for motion / 8-step turbo; `ref_image_size` match-vs-max; multiframe `frame_idx` guidance |
+| https://www.rundiffusion.com/minimax-h3-prompt-guide | SECONDARY | Aug 2026 | Restates the six sections, both marker sets, bracketed prefixes; adds a ten-item failure-mode list and a 7 000-character prompt cap |
+| https://deapi.ai/blog/…, https://www.dreampixelforge.com/blog/minimax-h3-prompts, https://minimax-h3-ai.com/blog/minimax-h3-prompt-guide/, https://domoai.app/blog/minimax-h3-prompt-guide, https://leadde.ai/blog/mini-max-h3-prompt-guide | SECONDARY | Aug 2026 | All restate the model card and the two official guides (three-field / six-section split, `[Shot 1]` untimestamped, MM:SS.mmm). One adds an unsourced "350–450 words for complex, 150–250 for simple" figure that conflicts with the official 350–500. No independent information. |
+| https://medium.com/…/minimax-h3-…, https://www.runpod.io/blog/minimax-h3-… | SECONDARY | Aug 2026 | Architecture restatement only |
+
+**Fetches attempted and not useful:** no arXiv/technical report for H3 exists as
+of 2026-09-07 (searched; only unrelated omni-modal papers returned). The GitHub
+mirror of the model repo has no `docs/` directory — the two guides live on the
+Hugging Face repo only.
+
+---
+
+## Claim-by-claim verdict — `dw/workflows/h3_context_ir.json`
+
+### Framing
+
+| Claim | Verdict |
+| --- | --- |
+| "H3-Base is trained to consume this exact format and degrades on anything else" | **PARTLY UNSOURCED.** The model card says H3-Context-IR "is critical to the quality of the final output, so we strongly recommend incorporating it into your generation pipeline or following the 'Prompting Guidance'". It never says the base model degrades on other input, and the base checkpoints accept free text. Directionally right, rhetorically stronger than any source. |
+| Output only the rewritten prompt, no commentary | **UNSOURCED** (harness convention, not a model fact). |
+| Structure = optional instruction block, one blank line, then the core fields | **CONFIRMED.** base guide §2.1: "The instruction must be the first line of the final prompt, followed by one blank line before the core fields." |
+
+### Instruction blocks
+
+| Claim | Verdict |
+| --- | --- |
+| T2VA: none, begin with the core fields | **CONFIRMED**, base §2.1. |
+| I2VA: `For the target video, at 0.00 seconds into the target video, <Picture 1> (from [Shot 1]) is fully referenced.` | **CONFIRMED verbatim**, base §2.1 and Case 2; also verbatim in the model card's own case-I2VA Context-IR output. |
+| FL2VA: `How the reference pictures align with the target video - Picture 1 (from Shot 1) …; Picture 2 (from Shot N) aligns with the S.SS-second mark …` | **CONFIRMED**, base §2.1, with one cosmetic deviation: the guide uses an em dash (`—`) after "target video", the repo uses a hyphen. The guide's FL2VA form genuinely drops the angle brackets and square brackets that the L2VA form keeps; the repo reproduces that asymmetry correctly. |
+| L2VA: `How the reference pictures align with the target video - <Picture 1> (from [Shot N]) aligns with the S.SS-second mark of the target video.` | **CONFIRMED**, base §2.1 (same em-dash nit). |
+| `S.SS` is the duration to two decimals; `N` is the index of the final shot | **CONFIRMED verbatim**, base §2.1. |
+| Ref2VA has no instruction block | **CONFIRMED** — ref guide §1 lists six sections beginning at `subject_definitions`; the model card's case-Ref2VA output starts at `subject_definitions:`. |
+
+### Core fields (T2VA/I2VA/FL2VA/L2VA)
+
+| Claim | Verdict |
+| --- | --- |
+| Order `integrated_multimodal_description` → `overall_soundscape` → `non_diegetic_music`, blank-line separated | **CONFIRMED**, base §2.2. |
+| Their three one-line definitions | **CONFIRMED near-verbatim**, base §2.2 and §4.1. |
+| **Omission:** the `N/A` convention | **MISSING.** base §4.6: `N/A` for `overall_soundscape` only when the user asks for complete silence; §4.7: `N/A` when there is no non-diegetic music. Both official examples use it. The repo never mentions `N/A`, so a model following the repo prompt will invent a score for a silent brief. |
+| **Omission:** length guidance (1–4 sentences soundscape, 1–3 music) and "do not repeat dialogue/singing/diegetic music in `overall_soundscape`" | **MISSING**, base §4.6/§4.7. |
+| **Omission:** "do not use abstract mood words or explain the emotional function of the score" in `non_diegetic_music` | **MISSING**, base §4.7. |
+
+### Ref2VA six sections
+
+| Claim | Verdict |
+| --- | --- |
+| Six sections in order `subject_definitions, summary, retention_analysis, detailed_description, overall_soundscape, non_diegetic_music` | **CONFIRMED**, ref guide §1 table; matches the model card's case-Ref2VA output. |
+| `<Subject N>` = reusable visible content (person, animal, object, scene, costume, style, action) | **CONFIRMED**, ref §2.1. |
+| `<Picture N>` = concrete frame / composition anchor; an image that only defines a subject is cited inside that subject's line | **CONFIRMED verbatim**, ref §2.2 ("do not create a standalone picture entry"). |
+| `<Video N>` = whole-video relationship (edit source, continuation point, temporal structure) | **CONFIRMED verbatim**, ref §2.3. |
+| `<Audio N>` = copied or referenced audio; name the speaker ID, `<Audio 1> is the voice-timbre reference for <Subject 1> (S1).` | **CONFIRMED verbatim**, ref §2.4 — the example sentence is identical. |
+| "One subject may draw on several assets (`whose appearance comes from <Picture 1> and whose walking motion comes from <Video 1>`)" | **CONFIRMED verbatim**, ref §2.1. |
+| Storyboard example `<Picture 3> is a storyboard reference for [Shot 1] and [Shot 2], defining their viewpoint, subject placement, and shot order.` | **CONFIRMED verbatim**, ref §2.2. |
+| "A label keeps the same meaning in every later section" | **CONFIRMED**, ref §2 blockquote. |
+| "The references appear in the order the request passes them, and that order is what the labels number" | **CONFIRMED but incomplete.** diffusers docs: order "labels them in the prompt presentation" and "a different order is a different request"; ComfyUI R2V tips: "Reference each input by tag in the exact order it was connected". **But** ref §2.5 adds a rule the repo omits: `<Video N>` and `<Audio N>` are numbered *independently within their own category*, so the same source video can be `<Video 1>` and `<Audio 2>`, and an ordinary reference video does not create an `<Audio N>` merely because the file has sound. Read as a single global counter, the repo's sentence is misleading. |
+
+### `summary`
+
+| Claim | Verdict |
+| --- | --- |
+| Square-bracketed task-type prefix + one short paragraph | **CONFIRMED**, ref §3. |
+| The six type names, joined with ` + `, no repeats | **CONFIRMED verbatim** — `keyframe completion`, `reference generation`, `video editing`, `video continuation`, `audio reuse`, `audio reference`, and "combine the task types with ` + ` and do not repeat a type", ref §3. |
+| Each type's one-line definition | **CONFIRMED near-verbatim**, ref §3 table. |
+| "A video that only lends camera, cuts or rhythm is reference generation, not editing or continuation" | **CONFIRMED verbatim**, ref §3. |
+| "A video edit opens with `The target video is an edited version of <Video N>.`" | **CONFIRMED**, ref §3 (guide writes `<Video 1>`; the repo's generalisation to `<Video N>` is correct). |
+| **Omission:** "when editing a source video, use `audio reuse` as well if its original audio remains audible"; "when continuing without copying the signal, use `audio reference` if the new audio only continues the original's audible characteristics" | **MISSING**, ref §3. |
+| **Omission:** "Do not introduce new reference labels in this section" | **MISSING**, ref §3. |
+
+### `retention_analysis`
+
+| Claim | Verdict |
+| --- | --- |
+| Visible-content markers `fully_preserved`, `partially_preserved`, `attribute_transfer`, `weak_reference` and their meanings | **CONFIRMED verbatim**, ref §4.1 — including that these are "fixed English values in the output format". |
+| Audio markers `fully_copy`, `partially_copy`, `reference`, `weak_reference` and their meanings | **CONFIRMED verbatim**, ref §4.2. |
+| Entry formats `<Subject 1> (appears in [Shot 1], [Shot 3]): fully_preserved - …`, `<Picture 2> ([Shot 1] first frame): fully_preserved - …`, `<Audio 1>: partially_copy - …` | **CONFIRMED verbatim** (the first two are the guide's own examples; the audio form matches `<Audio 1>: fully_copy - …`). |
+| "Choose the marker within the role `subject_definitions` gave the label; new actions, backgrounds or events are not losses of fidelity" | **CONFIRMED near-verbatim**, ref §4.2 closing paragraph. |
+| **Omission:** "Do not write `(Sx)` in `retention_analysis`" | **MISSING**, ref §5.4. This is an explicit prohibition the repo prompt does not carry. |
+| **Omission:** the video-structure entry form `<Video 1> (cut and pacing structure): weak_reference - …` | **MISSING** (minor), ref §4.1. |
+
+### `detailed_description`
+
+| Claim | Verdict |
+| --- | --- |
+| One or two sentences of overall style *before* `[Shot 1]`, with the example `The target video is in a realistic photographic style with soft window light.` | **CONFIRMED** — ref §5.2 table: "Established in one or two English sentences before `[Shot 1]`"; the model card's Ref2VA output opens `The target video is in realistic photographic style.` |
+| Then the same shot-by-shot timeline the other tasks put in `integrated_multimodal_description` | **CONFIRMED**, ref §5.1/§5.2. |
+| Content checklist: composition, appearance, environment and lighting, actions and state changes, camera movement, sound, and where referenced content takes effect | **CONFIRMED verbatim**, ref guide preamble ("Description detail"). |
+| "A generation task runs 350-500 words here" | **CONFIRMED verbatim**, ref §5.2 ("normally 350-500 English words"). Note one secondary source (dreampixelforge/deAPI family) gives 350–450 / 150–250 instead — **CONTRADICTED by the primary guide**; do not adopt it. |
+| "Dialogue-dense content fits the whole spoken timeline first" | **CONFIRMED**, ref §5.2. |
+| "Never reduce it to a plot summary or a list of reference relationships" | **CONFIRMED verbatim**, ref guide preamble. |
+| **Omission:** "Video-editing descriptions scale with the complexity of the source video and do not have to follow the generation-task range" and "A single shot does not automatically justify a shorter description" | **MISSING**, ref §5.2. |
+| **Omission:** the natural anchor phrasings `the shot begins from <Picture 1>` / `the shot's keyframe corresponds to <Picture 2>` / `the shot ends on <Picture 3>` | **MISSING**, ref §5.3. |
+
+### Continuity modes (`standalone` / `continuation`)
+
+**UNSOURCED — a repository invention.** Neither guide, the skill, the model card
+nor the Context-IR API defines a continuity mode. `standalone` appears in the ref
+guide only in the unrelated sense of "a standalone `<Picture N>` entry" / "a
+standalone audio asset". The hosted Context-IR API documents no continuation or
+segment-extension parameter at all.
+
+The *content* of the repo's continuation mode is nevertheless a defensible
+inference: `video continuation` is a real summary prefix (ref §3); marking the
+continuation-point video `fully_preserved` is consistent with the §4.1 marker
+definitions; and "one continuous shot, no cuts" is sound craft for chained
+segments. But the framing — that H3 recognises two continuity modes — is the
+repository's own and should be labelled as such in anything that teaches the
+format.
+
+### Shot-body rules
+
+| Claim | Verdict |
+| --- | --- |
+| Open `[Shot 1]` with overall style and initial composition; in Ref2VA the style sentence sits before `[Shot 1]` | **CONFIRMED**, base §4.1 + ref §5.2. |
+| Style vocabulary `Cinematic, live-action, 2D-animated, 3D CG, claymation, watercolor, vintage film` | **CONFIRMED verbatim**, base §4.1 (identical list, identical order). |
+| Derive style from the reference image when there is one, otherwise from the user's text | **CONFIRMED verbatim**, base §4.1. Mild tension with the official Skill's later tip (2026-08-11): "Prefer concrete visual and audio details over abstract words like 'cinematic' or 'beautiful'." |
+| Do not timestamp the first shot | **CONFIRMED**, base §4.2. |
+| Later shots open with a strictly increasing cut time inside the duration, e.g. `[Shot 2] At 00:03.500, the camera cuts to …` | **CONFIRMED verbatim**, base §4.2; format `[Shot N] At MM:SS.mmm` per ref §5.1. |
+| "A cut must introduce new information; when only framing or angle changes, use camera motion instead" | **CONFIRMED near-verbatim**, base §4.2 ("about the subject, space, state, viewpoint, or time"). The repo drops the enumeration of *what kind* of new information. |
+| FL2VA favours a single continuous shot unless asked otherwise | **CONFIRMED**, base §3.2. **Omission:** "The last frame must be reached by the final `[Shot N]` at the end of the video." |
+| Continuation mode allows no cut at all | **UNSOURCED** (part of the invented mode). |
+| **Omission:** the cut-verb vocabulary — `the camera cuts to`, `the shot cuts to`, `the shot transitions to`, `the shot changes to`, `the shot switches to`; and cross-dissolve / fade / wipe only when the user asks | **MISSING**, base §4.2. |
+
+### Camera motion
+
+**CONFIRMED verbatim and complete.** All 20 motion types in the repo's list
+(`Zoom In/Out, Push In, Pull Out, Pan Left/Right, Truck Left/Right, Tilt Up/Down,
+Pedestal Up/Down, Arc Shot, Tracking Shot, Static Shot, Shake Slightly/Strongly,
+POV, Roll Clockwise/Counterclockwise`) match base §4.3's table exactly, with no
+additions and no omissions. The amplitude phrases (`with small amplitude`, `with
+large amplitude`), the speed phrases (`at slow speed`, `at fast speed`), the
+"omit when medium and normal" rule, and "written as a natural English action
+within the shot rather than stacked as labels" are all verbatim.
+
+### Speakers and dialogue
+
+| Claim | Verdict |
+| --- | --- |
+| Stable IDs `(S1)`, `(S2)`, `(S1,S2)` for unison, kept across shots; non-vocalising characters get none | **CONFIRMED verbatim**, base §4.4. |
+| First appearance establishes character type, age, gender, on/off-screen, pitch, timbre, speaking rate, accent | **CONFIRMED verbatim**, base §4.4. |
+| Spoken/sung content inside `<d>[Language] …</d>` and nothing else; identity, action, delivery outside; wording and punctuation verbatim; never translate | **CONFIRMED verbatim**, base §4.4. |
+| Voiceover uses the exact phrase `says in an off-screen voiceover`, and the text after every voiceover `<d>` block states the lips remain completely closed | **CONFIRMED verbatim**, base §4.4. |
+| `<scenetrans>` at both connecting points of a line crossing a cut; `<cutoff>` when speech is truncated by the end of the video | **CONFIRMED**, base §4.4. **Omission:** the guide also requires *explicitly stating that the audio continues across the cut*, and supplies four phrasings (`continues seamlessly across the cut`, `continues uninterrupted into the next shot`, `carries over from the previous shot`, `remains audible across the transition`). |
+| "Invent dialogue only when the user asked for speech without supplying any" | **UNSOURCED** (sensible, no source either way). |
+| **Omission:** Ref2VA's combined form `<Subject N> (Sx)`, and `off-screen` marking for the same subject | **MISSING**, ref §5.4. |
+| **Omission:** `(Sx)` is assigned once by the order of *actual vocal events in the target video*, never renumbered in an `<Audio N>` definition | **MISSING**, ref §5.4. |
+| **Omission:** verbal cues that exist only inside a directly reused soundtrack use `<Audio N>` as the audible source and get no `(Sx)` | **MISSING**, ref §5.4. |
+| **Omission:** `[unclear]` for unintelligible spans instead of guessing; punctuation standardised to `, . ? !`, decorative punctuation removed, terminal `.`/`?`/`!` before `</d>` | **MISSING**, ref §5.4. |
+| **Omission:** "When only timbre, rhythm, emotion or delivery is referenced, do not carry the original dialogue from the reference audio into the target video." | **MISSING**, ref §5.4. |
+
+### On-screen text and the reference image
+
+| Claim | Verdict |
+| --- | --- |
+| Visible on-screen text in double quotation marks, verbatim, untranslated | **CONFIRMED verbatim**, base §4.5. |
+| The description must match what the reference image actually contains; `[Shot 1]` opens on its framing; never contradict it | **CONFIRMED** for I2VA, base §3.1 ("Character identity, clothing, colors, key objects, and spatial relationships should remain consistent"). The continuation-mode variant is unsourced. |
+| "Every detail must be something visible or audible" | **CONFIRMED verbatim**, base §4.1. |
+| "No camera hardware specs, no artist names, no quality tags such as 8k or ultra-detailed" | **UNSOURCED** — neither guide says this. It is a sensible generalisation of §4.1 but is not in any source. |
+| "No negative phrasing — H3 is guidance-distilled and has no negative prompt" | **CONFIRMED** on the mechanism: model card, "The released checkpoints are CFG-distilled Omni Transformer model weights"; diffusers docs, "Both transformer partitions are guidance-distilled … there is no guider, no `negative_prompt` and no `guidance_scale`". The prompt-writing *consequence* is the repo's inference, but a correct one. |
+
+---
+
+## Claim-by-claim verdict — `workflows/templates/minimax/README.md`
+
+| Claim | Verdict |
+| --- | --- |
+| `num_frames` must be of the form `17n + 5` | **CONFIRMED.** `align_num_frames(num_frames, frames_per_chunk=17, latents_per_chunk=5)` in `modular_pipelines/minimax_h3/modular_pipeline.py`; diffusers docs and ComfyUI tips both state the `17k+5` grid. Note the pipeline *snaps up* rather than rejecting, and warns. |
+| Between 124 and 345 | **CONFIRMED.** `min_duration = 5.0`, `max_duration = 15.0`, `fps = 24` → 120–360 frames → the `17n+5` members in range are 124 (n=7) … 345 (n=20). |
+| At a fixed 24 fps | **CONFIRMED.** `MINIMAX_H3_FPS = 24`; model card "Output frame rate 24 FPS". |
+| "that is 5.17 to 14.4 seconds" | **CONFIRMED.** 124/24 = 5.1667 s, 345/24 = 14.375 s. |
+| "in a single clip" | **CONFIRMED.** No extension/continuation mode exists in the model, the API or diffusers. |
+| **Nuance:** the model card and the Context-IR API say **4**–15 s | The 4-second floor is reachable only through the hosted API; the open checkpoint as integrated in diffusers enforces 5.0 s. The repo's floor is correct **for its own runtime**, but the README does not say why it differs from the model card, which will confuse anyone reading both. |
+| "Write the prompt for the length you are generating" | **CONFIRMED in spirit** by the official Skill's tip (2026-08-11): "Always match the total duration of the description to the requested video length (4–15 seconds)", and by the guides' requirement that cut times fall inside the duration. |
+| Music3 `audio_duration` is a ceiling, not a target; the piece ends where the music ends | **CONFIRMED verbatim** by `modular_blocks_minimax_music3.py`: "Upper bound on the generated audio length in seconds. The language model may stop earlier." The Music3 model card itself says nothing about it — diffusers is the only source. |
+| **Omission:** `audio_duration` is capped at 9000 frames (six minutes) | **MISSING** from the README. |
+| Turbo LoRA `lightx2v/Minimax-h3-Turbo` / `minimax_h3_fl2v_turbo_8step_v1.0_bf16.safetensors` at `num_inference_steps: 9` | **CONFIRMED as internally correct, but unexplained.** ModelTC's spec table: this file is the **544p mixed-aspect** FL2VA/T2VA 8-step LoRA, recommended NFE 8 (or 4). diffusers docs: "`num_inference_steps` counts sigma grid points, the terminal `0` included, so it drives one model evaluation less" — so 9 grid points = 8 NFE, exactly the recommendation. Neither the README nor any template comment records this reasoning, so the `9` looks arbitrary. |
+| Templates' default canvas 960×544 | **CONFIRMED as a legitimate choice.** diffusers docs endorse it explicitly ("960x544 runs about 2.3x faster per step than the trained 1344x768"), and it matches the 544p LoRA's training resolution, which is the *stronger* reason. But the README never states that H3's native canvas is a 768 short edge (1344×768 at 16:9), nor that the chosen LoRA is the 544p variant — so a reader raising the resolution would silently move off the LoRA's training distribution. |
+| Chain drift advice (reference the original subject in every segment, `last_segment` continuity, longest segments possible) | **UNSOURCED.** No official source discusses chaining; it is repository craft. Consistent with the diffusers docs' "a generation as a reference" hand-off, which is the mechanism it relies on. |
+| "Cuts erase drift; write shots, not takes" | **UNSOURCED** repository craft. Not contradicted by anything. |
+| Per-example "what it introduces" descriptions | Accurate against the templates read (`video-with-audio.json`, `reference-to-video.json`, `storyboard.json`, `dialogue-short.json`). |
+
+### One inconsistency found in the templates
+
+`storyboard.json` is a **Ref2VA** request (three references, `<Picture 1>` first
+frame plus two storyboard anchors) but loads
+`minimax_h3_fl2v_turbo_8step_v1.0_bf16.safetensors` — the **FL2VA/T2VA** LoRA —
+at 9 steps. `dialogue-short.json`, `music-video.json` and
+`chain-matched-and-aligned.json` do the same on reference-bearing requests. The
+other Ref2VA templates (`reference-to-video`, `composable-references`,
+`voice-timbre-reference`, `chain-video-continuity`,
+`generated-subject-reference`) correctly use no LoRA at 20 steps. Per ModelTC,
+the FL2VA LoRA is distilled against `transformer/`, while `ref2va` runs against
+`transformer_ref/`; a dedicated Ref2VA turbo LoRA exists (below).
+
+---
+
+## Missing knowledge
+
+Ordered by how much it would change what the repository does.
+
+1. **The official prompt-writing guides and Skill exist and are not referenced.**
+   `docs/VIDEO_PROMPT_WRITING_GUIDE_base_en.md`,
+   `docs/VIDEO_PROMPT_WRITING_GUIDE_ref_en.md` (in the model card repo), and
+   `skills/h3-prompt-writing/` on GitHub (skills last touched **2026-08-15**).
+   The repository's system prompt is derived from them but nothing says so, so
+   there is no way to re-verify it or track upstream changes.
+
+2. **A Ref2VA turbo LoRA exists** (`minimax_h3_ref2v_turbo_4step_v0.1_bf16.safetensors`,
+   and `minimax_h3_ref2v_turbo_8step_v1.0_768p_bf16.safetensors` present in the
+   HF repo as of **2026-09-04**, the latter newer than ModelTC's spec table).
+   Every Ref2VA template in the repository runs 20 unaccelerated steps.
+
+3. **Newer FL2VA LoRA versions**: `4step_v1.1_768p` and `4step_v1.2_768p`
+   (HF repo `lastModified` **2026-09-04**), plus `8step_v1.0_768p` — which
+   LightX2V Studio itself deploys, "improved video and audio generation quality"
+   (turbo README, **2026-08-27** screenshot). The repository pins the older
+   544p 8-step v1.0.
+
+4. **Scheduler shift values are part of the LoRA contract.** ModelTC: video/audio
+   shift `12 / 3` for the 544p LoRAs, `6 / 3` for the 768p ones; diffusers ships
+   `shift=12.0` video / `shift=3.0` audio by default. Moving to a 768p LoRA
+   without changing the shifts is a silent mismatch. Nothing in the repository
+   mentions shifts. (**2026-08/09**)
+
+5. **Reference-image resize policy.** ModelTC recommends `match` (reference pixel
+   area matched to the target canvas) because that is what distillation trained
+   on; diffusers' fixed 2048-pixel short edge is the `diffusers` policy. Also in
+   ComfyUI's tips. `storyboard.json` lowers `reference_image_short_edge` ad hoc
+   for memory but the repository has no notion of matching it to the canvas.
+   (**2026-08/09**)
+
+6. **The `N/A` convention** for `overall_soundscape` and `non_diegetic_music`
+   (base guide §4.6/§4.7) — the single most consequential prompt-format omission.
+
+7. **Dialogue-fidelity rules** the repository prompt omits: `[unclear]` for
+   unintelligible spans, punctuation standardisation and terminal punctuation
+   before `</d>`, "do not carry original dialogue over when only timbre is
+   referenced", "do not write `(Sx)` in `retention_analysis`", and the
+   `<Audio N>`-as-vocal-source rule for reused soundtracks (ref §5.4).
+
+8. **Cut-verb and audio-continuity vocabularies** (base §4.2, §4.4) — the
+   repository teaches one cut phrasing and no continuity phrasings.
+
+9. **`<Video N>` / `<Audio N>` are numbered independently within their own
+   category** and a reference video does not automatically produce an
+   `<Audio N>` (ref §2.5).
+
+10. **Model-level facts absent from the repository README**: native canvas is a
+    768-pixel short edge (max 768×1344), dimensions must be multiples of 32,
+    aspect ratios from 1:4 to 4:1, 32 kHz stereo output, 11 stable dialogue
+    languages, Ref2VA limits (≤9 images, ≤3 videos, ≤3 audio, ≤12 total; audio
+    references can never be the only references), and that H3-Regenerate-2K
+    (2K output) is API-only and not open-sourced.
+
+11. **Step-count guidance**: ComfyUI documents 20 steps as the non-turbo default
+    and ~25 for better motion quality. The repository's 20 matches the default
+    but has no note about the motion trade-off. (**2026-09-07** fetch)
+
+12. **Known failure modes** are documented nowhere in the repository. RunDiffusion
+    (secondary, Aug 2026) lists ten, including character inconsistency across
+    shots, reference-image dominance over the text, and storyboard skipping.
+    Treat as unconfirmed but worth testing.
+
+13. **`audio_duration` is capped at 9000 frames / six minutes** (Music3, diffusers).
+
+14. **No technical report or paper exists** for H3 as of 2026-09-07. Anything
+    claiming to cite one is fabricating.
+
+---
+
+## Assessment
+
+The Context-IR spec in `h3_context_ir.json` is **an accurate, compressed
+transcription of MiniMax's two official prompt-writing guides**, not an
+inference from examples. Sentence after sentence — the I2VA/FL2VA/L2VA
+instruction lines, the full 20-item camera-motion vocabulary, the six summary
+task types, both four-item retention-marker sets, the entry formats, the 350–500
+word figure, the voiceover phrase, the style list — is verbatim or near-verbatim
+against `VIDEO_PROMPT_WRITING_GUIDE_base_en.md` and `_ref_en.md`. Whoever wrote
+it had the guides open. Nothing in it is *wrong* about the format.
+
+Trustworthy as-is for a hand-writing skill: the task taxonomy and instruction
+blocks; the three core fields and the six Ref2VA sections with their order; every
+label definition; the summary prefix vocabulary and combination rule; both
+retention-marker vocabularies and entry shapes; the shot/timestamp/cut rules; the
+entire camera-motion vocabulary; speaker IDs; `<d>[Language]`, voiceover,
+`<scenetrans>`, `<cutoff>`; on-screen text.
+
+Needs correction or flagging:
+
+- **"Continuity modes" is invented.** No source defines standalone/continuation
+  as a Context-IR concept, and the hosted Context-IR API has no continuation
+  parameter. Keep the advice, relabel it as repository chaining craft.
+- **`N/A` is missing**, so silent-audio and no-score briefs will be answered with
+  fabricated sound. This is the one omission that produces materially wrong output.
+- **Reference numbering** is stated as one global order; the guide numbers
+  `<Video N>` and `<Audio N>` independently.
+- **"Degrades on anything else"** and the "no 8k / no artist names" rules are
+  unsourced editorialising — right in spirit, but should not be taught as the
+  model's contract.
+- The **dialogue-fidelity rules** of ref §5.4 are wholly absent and matter for any
+  Ref2VA request that reuses supplied speech.
+
+The README's numbers (`17n+5`, 124–345, 24 fps, `audio_duration` as a ceiling)
+are all confirmed against the installed diffusers source. Its two soft spots are
+the unexplained 5 s floor versus the model card's 4 s, and the unstated coupling
+between the 544p turbo LoRA, the 960×544 canvas and `num_inference_steps: 9`.

--- a/docs/superpowers/specs/2026-09-07-dw-plugin-skills-design.md
+++ b/docs/superpowers/specs/2026-09-07-dw-plugin-skills-design.md
@@ -1,0 +1,155 @@
+# dw plugin: model-family composition skills — design
+
+Package B of the Part 4 work in
+[agent-catalog-legibility.md](../../proposals/agent-catalog-legibility.md).
+It answers the open question of how model-specific knowledge reaches an
+agent: as a Claude Code plugin of small composition skills that defer the
+prompt format to the vendors' own published text. It depends on Package A
+([2026-09-07-ltx-h3-catalog-repair-design.md](2026-09-07-ltx-h3-catalog-repair-design.md))
+having landed, because the skills describe the repaired catalog.
+
+## Decisions taken
+
+- **Claude Code first, other MCP clients best-effort.** The knowledge lives in
+  the plugin. The engine's guide index is unchanged; the two template READMEs
+  remain what a non-Claude client can reach.
+- **A plugin in this repo, installed once.** Not written into workspaces, not
+  a separate repo.
+- **Composition only.** A skill teaches what is dw-specific: which template
+  fits which shape, the hard numeric rules, cost, and the run-and-judge loop.
+  It does not carry a prompt format.
+- **Prompt format comes from the vendor.** MiniMax publishes an official
+  `h3-prompt-writing` skill and two guides on the model card; Lightricks ships
+  the LTX-2.5 training-caption spec as system-prompt constants inside
+  diffusers. Both audits found the repo's own copies were the ones that had
+  drifted. The skills point at those sources rather than transcribe them.
+- **Two families in the first cut**, so the layout is designed against two
+  rather than refactored after one.
+
+## Layout
+
+```
+.claude-plugin/marketplace.json      # one entry: dw -> ./plugins/dw
+plugins/dw/
+  .claude-plugin/plugin.json         # name "dw", description, version
+  README.md                          # install, what each skill covers
+  skills/
+    minimax-h3/SKILL.md
+    ltx-2.5/SKILL.md
+```
+
+- `marketplace.json` names the marketplace `diffusers-workflow` and lists the
+  one plugin with a relative source. Install is two commands, shown in the
+  repo README's "Drive it from Claude Code" section after the MCP
+  registration:
+
+  ```
+  /plugin marketplace add dkackman/diffusers-workflow
+  /plugin install dw@diffusers-workflow
+  ```
+
+- **Version**: `plugin.json`'s version is the dw version. `scripts/release.sh`
+  writes it beside `pyproject.toml` in the same bump commit, and a test
+  asserts the two agree, so an installed plugin can be matched to the engine
+  it was written against.
+- **No MCP server declared** by the plugin. A skill's first instruction is to
+  call `get_server_info`, so it works against whatever dw server the session
+  already has. Remote servers need a URL and token per user, which a plugin
+  cannot carry.
+- **Nothing under `dw/`, `dw_mcp/` or the wheel changes.** The plugin is
+  repository content only. The repo's existing `.claude/` directory holds
+  only `settings.json` and is untouched.
+
+## Skill outline
+
+Both skills follow one outline, which is the mould for the next family.
+
+1. **Frontmatter.** `name` and a `description` written for triggering: the
+   model's name, the phrases a user says ("a video with sound", "a dialogue
+   scene", "a music video", "a clip with its own soundtrack", "extend this
+   clip"), and "when a dw MCP server is connected". The description is the
+   whole standing cost of the skill, so it is one or two sentences.
+2. **Before anything.** Call `get_server_info` for the accelerator and the
+   workspace; call `list_workflows` filtered by shape to find the family's
+   templates by their current names rather than trusting the ones the skill
+   quotes; read `get_workflow` on the one chosen.
+3. **Shape decision.** The README's reading-order tables rewritten as choices
+   an agent makes from the request. H3: one take up to 14 seconds; a longer
+   take by chain and what drift costs per seam; a piece with cuts as fresh
+   shots from shared portraits; appearance from an image reference; voice
+   from an audio reference; several boards in one generation under one
+   score. LTX-2.5: a single clip; first-frame or first-and-last conditioning;
+   the three-move two-stage flow for quality; the IC-LoRA upscale and what
+   it is not for; extend and chain, and that a single 481-frame pass reaches
+   20 seconds before either is needed.
+4. **Hard rules.** H3: `17n + 5` frames between 124 and 345 at 24 fps, the
+   768 short edge and 32-pixel grid, aspect 1:4 to 4:1, the 544p turbo LoRA
+   coupled to 960x544 and nine steps, Music3's duration as a ceiling and its
+   six-minute cap. LTX-2.5: `8k + 1` frames, 32-divisible dimensions, 24 fps,
+   the distilled sigmas are the schedule and not a knob, guidance off, the
+   stage-two sigmas and renoise scale, image conditioning re-compressed at
+   CRF 18 and needing a PIL image.
+5. **Prompts.** The vendor pointer and nothing else. H3: if the
+   `h3-prompt-writing` skill is installed, use it; else fetch the two guides
+   from the model card by their raw URLs; else run the family's
+   enhance-prompt template, which is the same format from the same guides.
+   LTX-2.5: the trained-caption spec, quoted from
+   `LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT` with the I2V variant's "describe only
+   what changes" rule, and the enhance-prompt template for a one-line idea.
+6. **Run and judge.** Validate; quote the listing's `cost` and get a
+   go-ahead; run; wait; look at the output with `get_output_image` or the
+   gallery URL; the family's failure modes to check for (H3: identity drift
+   across shots, a reference portrait imposing its framing, a skipped
+   storyboard; LTX-2.5: a scene cut caused by a prompt that contradicts the
+   image, softness when stage two was skipped).
+7. **Sources.** Each vendor source by URL with the date it was read.
+
+Size: each skill lands near the size of the README it derives from, and a
+test caps `SKILL.md` at 12 KB.
+
+The two READMEs keep their tables and gain one line pointing at the skill.
+
+## Drift tests
+
+`tests/test_plugin_skills.py`, run with the suite:
+
+- Every backticked name in a skill that looks like a catalog path
+  (`templates/...` or `models/...`) resolves to a file under `workflows/`.
+- Every numeric rule the skill states is checked against the source it
+  comes from: H3's frame arithmetic and canvas limits against the diffusers
+  MiniMax modular-pipeline constants; LTX-2.5's frame and dimension rules,
+  the distilled sigma count and the stage-two renoise value against the
+  LTX-2 pipeline module. A diffusers upgrade that moves one fails here.
+- The LTX-2.5 skill's quoted prompt spec equals
+  `LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT`, whitespace aside. The quote is the one
+  place the plugin carries vendor text, and it is tied to the library that
+  ships it.
+- `plugin.json`'s version equals `pyproject.toml`'s.
+- Each `SKILL.md` is under the size cap and has a `description` that names
+  its model.
+
+The tests import diffusers, so they carry the same skip the existing
+pipeline-signature tests use when it is absent.
+
+## Acceptance: the cold drill
+
+Run twice against lem after Package A is merged and the server restarted,
+from the scratch directory the earlier drills used:
+
+1. The plugin installed. Prompt: "a short multi-shot video with cuts between
+   the shots", the one the earlier probe answered with three unrelated
+   LTX-2 shots.
+2. The plugin not installed, same prompt, as the control.
+
+Pass, for the first run: the H3 skill fires; the agent chooses the cuts
+template with shared portraits; it writes shots in Context-IR from the
+vendor guides or the official skill rather than an invented layout; it
+quotes cost and waits for a go-ahead; the finished piece holds the cast
+across shots. The transcript path and the server-log lines are recorded in
+the ledger row beside the earlier probe.
+
+## Ledger
+
+The Part 4 row records the decision, the plugin path, the drill result, and
+the mould for the next family: copy a skill, follow the outline, add the
+family's rules to the drift test, cite the vendor.

--- a/docs/superpowers/specs/2026-09-07-ltx-h3-catalog-repair-design.md
+++ b/docs/superpowers/specs/2026-09-07-ltx-h3-catalog-repair-design.md
@@ -1,0 +1,187 @@
+# LTX-2.5 and MiniMax H3 catalog repair — design
+
+Package A of the Part 4 work in
+[agent-catalog-legibility.md](../../proposals/agent-catalog-legibility.md).
+It repairs what two vendor-source audits found wrong in the catalog's
+model-specific content, so that the skills in Package B
+([2026-09-07-dw-plugin-skills-design.md](2026-09-07-dw-plugin-skills-design.md))
+describe something true. The audits, with per-claim citations, are
+[2026-09-07-ltx-2.5-audit.md](../../proposals/audits/2026-09-07-ltx-2.5-audit.md)
+and
+[2026-09-07-minimax-h3-audit.md](../../proposals/audits/2026-09-07-minimax-h3-audit.md).
+
+## Why
+
+The catalog's H3 and LTX-2.5 knowledge was written from the vendors' own
+material but never cites it, and two things drifted from it: the LTX two-stage
+template stops after the latent upsample and skips the refinement pass every
+primary source describes, and the LTX prompt library is in a genre the model
+was not trained on. The H3 Context-IR builtin is a faithful compression of
+MiniMax's two prompt-writing guides with three defects of its own. Everything
+here is a data change under the proposal's principle: guide prose, template
+JSON, stored prompts. One engine question is named below and is the only
+place code might move.
+
+## Scope
+
+In: the eight LTX-2.5 templates' README and the two-stage template, the six
+stored LTX prompts, the `h3_context_ir` builtin's system prompt, the MiniMax
+templates README, the LTX-2.5 section of `RECIPES_24GB.md`, and the ledger row.
+
+Out, recorded as dated follow-ups in the ledger and not done here: the DFR
+pipeline as the newer quality path, temporal upscaling, generated keyframe
+slots, the newer H3 turbo LoRAs and their scheduler shifts, the reference
+resize policy, fp8/NVFP4, HDR, retake, native multishot. The keyframe
+strength question (1.0 versus the guiding range) is also out; the template
+works as built and the audit calls it arguable, not wrong.
+
+## 1. The LTX-2.5 two-stage template
+
+`workflows/templates/ltx2/two-stage.json` becomes the three-move flow the
+model card, Lightricks' pipeline notes and the diffusers docs all describe:
+
+1. **base**: unchanged settings (768x448, 121 frames, the 8 distilled sigmas,
+   guidance off), but `output_type` becomes `"{latent}"` and `save` stays
+   false. The step returns the video latents and the audio latents.
+2. **upscale**: `LTX2LatentUpsamplePipeline` takes `latents` from the base
+   step instead of decoded frames, so nothing round-trips through pixels.
+   `output_type` is `"{latent}"`.
+3. **refine**: the same `LTX2Pipeline` configuration as the base step, so the
+   pipeline cache serves it without a second load. Arguments: the prompt and
+   negative prompt, `latents` from the upscale step, `audio_latents` from the
+   base step, `sigmas` as
+   `constant:diffusers.pipelines.ltx2.utils.STAGE_2_DISTILLED_SIGMA_VALUES`,
+   `noise_scale` as the first value of that schedule, width and height at
+   twice the base values, the same frame count and frame rate, guidance off
+   as before, and `output_type` `"{np}"`. The result is `video/mp4`, muxed
+   with the audio the pipeline decodes from the carried audio latents.
+
+The `pair_audio` step goes: stage two produces its own muxed output. The
+description says what the three moves are and why the audio is generated in
+stage one and only carried through stage two.
+
+**The engine question.** The base step returns a pipeline output object with
+two tensors. `previous_result:base` today yields the object's artifacts;
+whether `previous_result:base.<field>` can name the video latents and the
+audio latents separately depends on the field names `LTX2PipelineOutput`
+uses when `output_type` is latent, and on `get_artifact_properties` reaching
+them. The plan's first task reads `pipeline_output.py` and tries the
+reference in a unit test with a stub output. If the property route works,
+no engine change. If it does not, the smallest change that makes it work is
+in `dw/result.py` or `dw/previous_results.py`, covered by a test, and named
+in the ledger.
+
+`noise_scale` as "the first value of the constant" has no reference syntax
+today. The template writes the literal `0.909375` with a comment-bearing
+description sentence naming the constant it copies, and
+`tests/test_catalog_structure.py` gains a check that the literal equals
+`STAGE_2_DISTILLED_SIGMA_VALUES[0]` from the installed library, so a
+diffusers change to the schedule fails a test rather than silently
+mis-noising.
+
+**Acceptance**: the template validates; a run on lem completes; the refined
+output is visibly sharper than the upscale-only output of the previous
+template at the same seed (kept side by side in the run's gallery entry);
+`cost` is remeasured and written; `RECIPES_24GB.md`'s sharpness sentence is
+reinstated only if the comparison supports it.
+
+## 2. The LTX-2.5 prompt library
+
+The six files under `prompts/ltx2/` are rewritten to the trained-caption
+format that `LTX2_5_T2V_DEFAULT_SYSTEM_PROMPT` in the installed diffusers
+specifies, and that the audit summarises as:
+
+- one paragraph, roughly 150 to 220 words, present-progressive verbs;
+- opens on the action, never "The scene opens" or "We see";
+- for every shot a shot type, a camera motion (stated even when static) and
+  a viewpoint, woven into the prose;
+- the soundscape interleaved chronologically with the action, not appended;
+- observable detail only, plain colour words, no quality tags, no artist
+  names, dialogue quoted exactly.
+
+The two prompts that serve image-conditioned templates
+(`marmot_robot_overlords`, `polaroid_lighthouse`) follow the I2V variant
+instead: describe what changes from the image and do not restate what the
+image already shows. `intended_model` becomes `ltx-2.5` on all six, and the
+template `summary` fields that say "LTX-2" say "LTX-2.5". The
+`enhance-prompt` template's one-line inline idea stays as it is, because
+that is the enhancer's input.
+
+Each rewritten prompt keeps its subject and its `description`, so the
+gallery and the templates that reference it by name are unaffected.
+
+**Acceptance**: a test in `tests/test_prompts.py` (or a new
+`tests/test_ltx_prompt_library.py`) asserts every `prompts/ltx2/*.json` text
+is 140 to 240 words, one paragraph, and contains none of a short forbidden
+list (`8k`, `ultra-detailed`, `photorealistic`, `vibrant colors`, `The scene
+opens`, `We see`). Two of the six are run on lem through the text-to-video
+template and looked at.
+
+## 3. The H3 Context-IR builtin
+
+`dw/workflows/h3_context_ir.json`'s `system_prompt` changes in five places,
+each traceable to the audit:
+
+1. **`N/A`**: `overall_soundscape` and `non_diegetic_music` are written as
+   `N/A` when the brief has no ambient sound or no score, per the base guide.
+   Without it the enhancer invents audio for a silent brief.
+2. **Reference numbering**: `<Video N>` and `<Audio N>` are numbered
+   independently within their own category, and a video reference does not
+   by itself produce an `<Audio N>`. The current text says one global order.
+3. **Continuity modes relabelled**: the standalone/continuation block stays,
+   because dw's chain feature feeds "Continuity: continuation" into the
+   enhancer's user message (`resolve_chain_prompts`), but the text says it is
+   this engine's convention for writing one segment of a chained take and
+   not part of Context-IR.
+4. **Dialogue fidelity**: the ref guide's rules that the current text omits:
+   `[unclear]` for unintelligible spans, terminal punctuation before `</d>`,
+   no `(Sx)` speaker IDs inside `retention_analysis`, and no carrying of
+   original dialogue when only a voice's timbre is referenced.
+5. **Two unsourced lines removed**: "degrades on anything else" and the
+   "no 8k or artist names" rule. The guidance that H3 has no negative prompt
+   stays; it is confirmed.
+
+A first line in the system prompt cites the two guides by their paths in the
+model card repo, so the next audit starts from a source.
+
+**Acceptance**: a test asserts the system prompt contains `N/A` guidance and
+the phrase that relabels continuity as an engine convention; the
+`enhance-prompt` template runs on lem with a deliberately silent brief and
+the output's two audio fields read `N/A`.
+
+## 4. The two READMEs
+
+`workflows/templates/minimax/README.md` and `workflows/templates/ltx2/README.md`:
+
+- every table link names the file that exists (the templates were renamed to
+  kebab-case; the links still name the old ids);
+- the LTX README's model link points at the LTX-2.5 repo, not LTX-Video;
+- a first paragraph names the vendor sources: for H3 the two prompt-writing
+  guides and the `h3-prompt-writing` skill in MiniMax's GitHub repo; for
+  LTX-2.5 the model card, Lightricks' `ltx-pipelines` docs, and the
+  system-prompt constants in diffusers;
+- the H3 README gains one paragraph of model facts the audit found missing:
+  the 768-pixel short edge and 32-pixel grid, aspect ratios 1:4 to 4:1, that
+  the 5-second floor is diffusers' constraint where the model card says 4,
+  and that the 544p turbo LoRA, the 960x544 canvas and nine steps are one
+  coupled choice;
+- the LTX README's "recommended quality flow" line describes the repaired
+  three-move flow and notes that Lightricks' newer DFR pipeline is the
+  follow-up.
+
+A catalog-structure test walks both READMEs for relative links and asserts
+each resolves, so a future rename fails the suite.
+
+## 5. Ledger and follow-ups
+
+The Part 4 ledger row records what changed, the remeasured costs, and a dated
+"missing knowledge" list drawn from both audits so the next model-family pass
+starts from it.
+
+## Verification order
+
+1. Unit tests and the catalog-structure suite locally.
+2. On lem, on this branch with a server restart (the builtin and any engine
+   change need one): two-stage, two rewritten prompts through text-to-video,
+   the H3 enhancer with a silent brief.
+3. Costs written, ledger updated, PR.


### PR DESCRIPTION
…d LTX-2.5 vendor audits

Two vendor-source audits found the H3 Context-IR builtin is a faithful compression of MiniMax's published guides with three defects, and that the LTX-2.5 two-stage template skips its refinement pass and the LTX prompt library is in a genre the model was not trained on. Both vendors publish the prompt format themselves, so the plugin's skills teach composition and defer format to those sources.